### PR TITLE
Fixes for secure environments

### DIFF
--- a/addons/addon-base-post-deployment/packages/base-post-deployment/lib/steps/add-auth-providers.js
+++ b/addons/addon-base-post-deployment/packages/base-post-deployment/lib/steps/add-auth-providers.js
@@ -28,6 +28,7 @@ const settingKeys = {
   fedIdpNames: 'fedIdpNames',
   fedIdpDisplayNames: 'fedIdpDisplayNames',
   fedIdpMetadatas: 'fedIdpMetadatas',
+  fedIdpAttributeMap: 'fedIdpAttributeMap',
   defaultAuthNProviderTitle: 'defaultAuthNProviderTitle',
   cognitoAuthNProviderTitle: 'cognitoAuthNProviderTitle',
   cognitoUserPoolDomainPrefix: 'cognitoUserPoolDomainPrefix',
@@ -64,6 +65,7 @@ class AddAuthProviders extends Service {
     const fedIdpNames = this.settings.optionalObject(settingKeys.fedIdpNames, []);
     const fedIdpDisplayNames = this.settings.optionalObject(settingKeys.fedIdpDisplayNames, []);
     const fedIdpMetadatas = this.settings.optionalObject(settingKeys.fedIdpMetadatas, []);
+    const fedIdpAttributeMap = this.settings.optionalObject(settingKeys.fedIdpAttributeMap, []);
 
     // If user pools aren't enabled and no IdPs are configured, skip user pool creation
     const idpsNotConfigured = [fedIdpIds, fedIdpNames, fedIdpDisplayNames, fedIdpMetadatas].some(
@@ -82,6 +84,7 @@ class AddAuthProviders extends Service {
           name: fedIdpNames[idx],
           displayName: fedIdpDisplayNames[idx],
           metadata: fedIdpMetadatas[idx],
+          attributeMap: fedIdpAttributeMap[idx] || "{}",
         };
       }),
     );

--- a/addons/addon-base-rest-api/packages/services/lib/authentication-providers/built-in-providers/cogito-user-pool/create-cognito-user-pool-input-manifest.js
+++ b/addons/addon-base-rest-api/packages/services/lib/authentication-providers/built-in-providers/cogito-user-pool/create-cognito-user-pool-input-manifest.js
@@ -126,6 +126,12 @@ const inputManifestForCreate = {
           title: 'Identity Provider SAML Metadata XML',
           desc: 'Enter identity provider SAML metadata XML document for setting up trust.',
         },
+        {
+          name: 'federatedIdentityProviders[0].attributeMap',
+          type: 'textAreaInput',
+          title: 'JSON custom SAML attribute mapping',
+          desc: 'Enter a custom SAML mapping for name, given_name, family_name, or email.',
+        },
       ],
     },
   ],

--- a/addons/addon-base-rest-api/packages/services/lib/authentication-providers/built-in-providers/cogito-user-pool/create-cognito-user-pool-schema.json
+++ b/addons/addon-base-rest-api/packages/services/lib/authentication-providers/built-in-providers/cogito-user-pool/create-cognito-user-pool-schema.json
@@ -70,6 +70,10 @@
           "metadata": {
             "$id": "#/properties/federatedIdentityProviders/properties/metadata",
             "type": "string"
+          },
+          "attributeMap": {
+            "$id": "#/properties/federatedIdentityProviders/properties/attributeMap",
+            "type": "string"
           }
         }
       }

--- a/addons/addon-base-rest-api/packages/services/lib/authentication-providers/built-in-providers/cogito-user-pool/provisioner-service.js
+++ b/addons/addon-base-rest-api/packages/services/lib/authentication-providers/built-in-providers/cogito-user-pool/provisioner-service.js
@@ -441,17 +441,18 @@ class ProvisionerService extends Service {
         metaDataInfo.MetadataFile = metadata;
       }
 
+      const attributeMap = JSON.parse(idp.attributeMap || "{}");
+
       const params = {
         ProviderDetails: metaDataInfo,
         ProviderName: idp.name /* required */,
         ProviderType: 'SAML' /* required */, // TODO: Add support for other Federation providers
         UserPoolId: providerConfig.userPoolId /* required */,
         AttributeMapping: {
-          // TODO: Add support for configurable attributes mapping
-          name: 'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name',
-          given_name: 'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname',
-          family_name: 'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname',
-          email: 'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress',
+          name: attributeMap.name || 'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name',
+          given_name: attributeMap.given_name || 'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname',
+          family_name: attributeMap.family_name || 'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname',
+          email: attributeMap.email || 'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress',
         },
         IdpIdentifiers: [idp.id],
       };

--- a/addons/addon-base-rest-api/packages/services/lib/authentication-providers/built-in-providers/cogito-user-pool/update-cognito-user-pool-input-manifest.js
+++ b/addons/addon-base-rest-api/packages/services/lib/authentication-providers/built-in-providers/cogito-user-pool/update-cognito-user-pool-input-manifest.js
@@ -98,6 +98,12 @@ const inputManifestForUpdate = {
           title: 'Identity Provider SAML Metadata XML',
           desc: 'Enter identity provider SAML metadata XML document for setting up trust.',
         },
+        {
+          name: 'federatedIdentityProviders|-0-|/attributeMap',
+          type: 'textAreaInput',
+          title: 'JSON custom SAML attribute mapping',
+          desc: 'Enter a custom SAML mapping for name, given_name, family_name, or email.',
+        },
       ],
     },
   ],

--- a/addons/addon-base/packages/services/lib/settings/env-settings-service.js
+++ b/addons/addon-base/packages/services/lib/settings/env-settings-service.js
@@ -134,6 +134,7 @@ class EnvBasedSettingsService extends Service {
     try {
       value = JSON.parse(value);
     } catch (e) {
+      console.error('JSON Parse error', e);
       throw error();
     }
 

--- a/addons/addon-base/packages/services/lib/settings/env-settings-service.js
+++ b/addons/addon-base/packages/services/lib/settings/env-settings-service.js
@@ -134,7 +134,6 @@ class EnvBasedSettingsService extends Service {
     try {
       value = JSON.parse(value);
     } catch (e) {
-      console.error('JSON Parse error', e);
       throw error();
     }
 

--- a/addons/addon-register/packages/register/lib/services/register-service.js
+++ b/addons/addon-register/packages/register/lib/services/register-service.js
@@ -13,8 +13,8 @@
  *  permissions and limitations under the License.
  */
 const Service = require('@aws-ee/base-services-container/lib/service');
-const { toUserNamespace } = require('@aws-ee/base-service/lib/user/helpers/user-namespace');
-const { generateId } = require('@aws-ee/base-service/lib/helpers/utils');
+const { toUserNamespace } = require('@aws-ee/base-services/lib/user/helpers/user-namespace');
+const { generateId } = require('@aws-ee/base-services/lib/helpers/utils');
 
 const jsonSchema = require('../schemas/register-user.json');
 

--- a/addons/addon-register/packages/register/package.json
+++ b/addons/addon-register/packages/register/package.json
@@ -7,7 +7,7 @@
     "@aws-ee/base-raas-ui": "workspace:*",
     "@aws-ee/base-ui": "workspace:*",
     "@aws-ee/base-controllers": "workspace:*",
-    "@aws-ee/base-service": "workspace:*",
+    "@aws-ee/base-services": "workspace:*",
     "@aws-ee/base-services-container": "workspace:*",
     "aws-sdk": "^2.1000.0",
     "lodash": "^4.17.21",

--- a/main/config/settings/example.yml
+++ b/main/config/settings/example.yml
@@ -114,6 +114,22 @@ HostedZoneId: 'Z02455261RJ9QQPVHFZGA'
 # TODO: Remove saml-metadata/datalake-example-idp-metadata.xml file and replace this setting to use sample file
 #fedIdpMetadatas: '["s3://${self:custom.settings.deploymentBucketName}/saml-metadata/datalake-example-idp-metadata.xml"]'
 
+# Array of identity provider SAML mappings. This array should be in same order as the "fedIdpIds".
+# The array should contain a stringified json object with any of the following attributes:
+# name, given_name, family_name, or email. If any of these are missing, or a default of "{}" is given,
+# then the default mappings below are used:
+#   name: http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name
+#   given_name: http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname
+#   family_name: http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname
+#   email: http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress
+#
+# An example of replacing only the mapping for the name attribute of one idp to an email attribute would look like this,
+#  fedIdpAttributeMap: '["{\"name\": \"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/email\"}"]'
+#
+# If you do not want to connect to Active Directory then leave this setting as empty array as follows.
+#
+# fedIdpAttributeMap: '[]'
+
 # If a Cognito user pool is setup for the solution, this setting indicates whether native
 # Cognito users should be used or if the Cognito user pool will only be used to federate to other identity providers (listed above)
 # IMPORTANT: We recommend keeping this flag value set to true when installing SWB for the very first time so a root user can log in for user management.

--- a/main/config/settings/example.yml
+++ b/main/config/settings/example.yml
@@ -121,6 +121,11 @@ HostedZoneId: 'Z02455261RJ9QQPVHFZGA'
 # Stack policies are applied here: addons/addon-stack-policy/packages/stack-policy/lib/steps/update-cfn-stack-policy.js
 #enableEgressStore: false
 
+# If a Cognito user pool is setup for the solution, this setting indicates whether native
+# Cognito users should be used or if the Cognito user pool will only be used to federate to other identity providers (listed above)
+# IMPORTANT: We recommend keeping this flag value set to true when installing SWB for the very first time so a root user can log in for user management.
+#enableNativeUserPoolUsers: false
+
 # Determine whether workspace should be accessible only through AppStream
 # NOTE: Once the isAppStremEnabled is set to true, the AppStrem feature will be enabled and can NOT be toggled off.
 # If you toggle the AppStream feature from true to false and redeploy the whole solution, the backend stack deployment should error out with following message:

--- a/main/config/settings/example.yml
+++ b/main/config/settings/example.yml
@@ -114,17 +114,17 @@ HostedZoneId: 'Z02455261RJ9QQPVHFZGA'
 # TODO: Remove saml-metadata/datalake-example-idp-metadata.xml file and replace this setting to use sample file
 #fedIdpMetadatas: '["s3://${self:custom.settings.deploymentBucketName}/saml-metadata/datalake-example-idp-metadata.xml"]'
 
+# If a Cognito user pool is setup for the solution, this setting indicates whether native
+# Cognito users should be used or if the Cognito user pool will only be used to federate to other identity providers (listed above)
+# IMPORTANT: We recommend keeping this flag value set to true when installing SWB for the very first time so a root user can log in for user management.
+#enableNativeUserPoolUsers: false
+
 # Enable the Egress Store feature would allow researchers to securely egress data from lockdown Workspace
 # NOTE: Once the enableEgressStore is set to true, the egress store feature will be enabled and can NOT be toggled off.
 # If you toggle the egress store from true to false and redeploy the whole solution, the backend stack deployment should error out with following message:
 # Error validating existing stack policy: Unknown logical id 'LogicalResourceId/EgressStore*' in statement {} - stack policies can only be applied to logical ids referenced in the template
 # Stack policies are applied here: addons/addon-stack-policy/packages/stack-policy/lib/steps/update-cfn-stack-policy.js
 #enableEgressStore: false
-
-# If a Cognito user pool is setup for the solution, this setting indicates whether native
-# Cognito users should be used or if the Cognito user pool will only be used to federate to other identity providers (listed above)
-# IMPORTANT: We recommend keeping this flag value set to true when installing SWB for the very first time so a root user can log in for user management.
-#enableNativeUserPoolUsers: false
 
 # Determine whether workspace should be accessible only through AppStream
 # NOTE: Once the isAppStremEnabled is set to true, the AppStrem feature will be enabled and can NOT be toggled off.

--- a/main/solution/post-deployment/config/infra/functions.yml
+++ b/main/solution/post-deployment/config/infra/functions.yml
@@ -19,6 +19,7 @@ postDeployment:
     APP_FED_IDP_NAMES: ${self:custom.settings.fedIdpNames}
     APP_FED_IDP_DISPLAY_NAMES: ${self:custom.settings.fedIdpDisplayNames}
     APP_FED_IDP_METADATAS: ${self:custom.settings.fedIdpMetadatas}
+    APP_FED_IDP_ATTRIBUTE_MAP: ${self:custom.settings.fedIdpAttributeMap}
     APP_WEBSITE_URL: ${self:custom.settings.websiteUrl}
     APP_DEFAULT_AUTH_N_PROVIDER_TITLE: ${self:custom.settings.defaultAuthNProviderTitle}
     APP_COGNITO_AUTH_N_PROVIDER_TITLE: ${self:custom.settings.cognitoAuthNProviderTitle}

--- a/main/solution/post-deployment/config/settings/.defaults.yml
+++ b/main/solution/post-deployment/config/settings/.defaults.yml
@@ -109,6 +109,23 @@ fedIdpDisplayNames: '[]'
 # fedIdpMetadatas: '[]'
 fedIdpMetadatas: '[]'
 
+# Array of identity provider SAML mappings. This array should be in same order as the "fedIdpIds".
+# The array should contain a stringified json object with any of the following attributes:
+# name, given_name, family_name, or email. If any of these are missing, or a default of "{}" is given,
+# then the default mappings below are used:
+#   name: http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name
+#   given_name: http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname
+#   family_name: http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname
+#   email: http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress
+#
+# An example of replacing only the mapping for the name attribute of one idp to an email attribute would look like this,
+#  fedIdpAttributeMap: '["{\"name\": \"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/email\"}"]'
+#
+# If you do not want to connect to Active Directory then leave this setting as empty array as follows.
+#
+# fedIdpAttributeMap: '[]'
+fedIdpAttributeMap: '[]'
+
 # ================================ DB Settings ===========================================
 
 # DynamoDB table name for the deployment store

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2030,7 +2030,7 @@ importers:
       '@aws-ee/base-raas-ui': workspace:*
       '@aws-ee/base-serverless-settings-helper': workspace:*
       '@aws-ee/base-serverless-ui-tools': workspace:*
-      '@aws-ee/base-service': workspace:*
+      '@aws-ee/base-services': workspace:*
       '@aws-ee/base-services-container': workspace:*
       '@aws-ee/base-ui': workspace:*
       '@babel/cli': ^7.8.4
@@ -2079,7 +2079,7 @@ importers:
     dependencies:
       '@aws-ee/base-raas-ui': link:../../../addon-base-raas-ui/packages/base-raas-ui
       '@aws-ee/base-ui': link:../../../addon-base-ui/packages/base-ui
-      '@aws-ee/base-service': link:../../../addon-base/packages/services
+      '@aws-ee/base-services': link:../../../addon-base/packages/services
       '@aws-ee/base-controllers': link:../../../addon-base-rest-api/packages/base-controllers
       '@aws-ee/base-services-container': link:../../../addon-base/packages/services-container
       aws-sdk: 2.1015.0


### PR DESCRIPTION
- Fixes a typo that could break the register package if someone regenerated the lock file. Typically, during deploy it just uses what is there so this bug has no impact on deployments using the existing lock file.
- Adds documentation and example config to disable Cognito Native User Pool login on deployments.
- Adds ability to provide custom federated IDP SAML mappings, with backwards compatible default values.

---

Checklist:
- [X] Have you successfully deployed to an AWS account with your changes?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.