### PR TITLE
Increase WAF rate from 500 to 4000

### DIFF
--- a/main/solution/post-deployment/serverless.yml
+++ b/main/solution/post-deployment/serverless.yml
@@ -71,7 +71,7 @@ custom:
   registrationWAF:
     albExportName: "${self:custom.settings.awsRegionShortName}-${self:custom.settings.solutionName}-LoadBalancerFullName"
     name: "${self:custom.settings.awsRegionShortName}-${self:custom.settings.solutionName}-WAF"
-    rateLimit: 500 # Per ip, per 5 minutes
+    rateLimit: 4000 # Per ip, per 5 minutes
 
 functions: ${file(./config/infra/functions.yml)}
 


### PR DESCRIPTION
This is to relieve the ddos rate limiting for the overall app so it performs better, while keeping a limit enough to protect the register route. In the future, I will test out a WAF rule change that only applies rate limiting to the register ui and api routes.