### PR TITLE
Update waf permissions to wafv2.

### DIFF
--- a/main/cicd/cicd-pipeline/config/infra/cloudformation.yml
+++ b/main/cicd/cicd-pipeline/config/infra/cloudformation.yml
@@ -261,7 +261,7 @@ Resources:
               - elasticloadbalancing:*
               - ec2:*
               - logs:*
-              - waf:*
+              - wafv2:*
               - application-autoscaling:*
             Effect: Allow
             Resource: '*'


### PR DESCRIPTION
Apparently, you can deploy the WAF resources without needing special permissions in the pipeline, but if the stack needs updating that's when the permissions are needed to compare the stacks. So, I didn't originally notice that the WAF resource has a special namespace for v2. This updates the app deployer role to give blanket permission for the pipeline to view and update WAFv2 resources (we're not deploying any v1 resources) instead of WAFv1.

---

Checklist:
- [x] Have you successfully deployed to an AWS account with your changes?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.