### PR TITLE
Adds default RStudio auto-save settings

### DIFF
--- a/main/solution/post-deployment/config/environment-files/bootstrap.sh
+++ b/main/solution/post-deployment/config/environment-files/bootstrap.sh
@@ -193,6 +193,10 @@ case "$(env_type)" in
         sudo yum localinstall -y "${FILES_DIR}/offline-packages/ec2-linux/fuse-2.9.2-11.amzn2.x86_64.rpm"
         echo "Finish installing fuse"
         printf "\n# Mount S3 study data\nmount_s3.sh\n\n" >> "/home/rstudio-user/.bash_profile"
+
+        # set autosave
+        mkdir -p /home/rstudio-user/.config/rstudio
+        echo '{"initial_working_directory":"~","auto_save_on_blur":true,"auto_save_on_idle":"commit","posix_terminal_shell":"bash"}' > /home/rstudio-user/.config/rstudio/rstudio-prefs.json
         ;;
     "rstudiov2") # Add mount script to bash profile and generate self signed certificates
         echo "Generate SSL certs"
@@ -201,6 +205,10 @@ case "$(env_type)" in
         yum install -y fuse-2.9.2
         echo "Finish installing fuse"
         printf "\n# Mount S3 study data\nmount_s3.sh\n\n" >> "/home/rstudio-user/.bash_profile"
+
+        # set autosave
+        mkdir -p /home/rstudio-user/.config/rstudio
+        echo '{"initial_working_directory":"~","auto_save_on_blur":true,"auto_save_on_idle":"commit","posix_terminal_shell":"bash"}' > /home/rstudio-user/.config/rstudio/rstudio-prefs.json
         ;;
 esac
 


### PR DESCRIPTION
Adds a default auto-save, specific to SWB, to ensure that files are saved so users don't lose work when check-idle script executes an on idle shutdown signal.

Deployed to aim-ahead-dbmi-dev already.

Checklist:
- [X] Have you successfully deployed to an AWS account with your changes?

----

Ticket: ALS-4005


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.