### PR TITLE
WAF updates to allow canary traffic through bot rules

### DIFF
--- a/main/solution/post-deployment/config/infra/registrationWAF.yml
+++ b/main/solution/post-deployment/config/infra/registrationWAF.yml
@@ -20,6 +20,16 @@ Resources:
             RateBasedStatement:
               AggregateKeyType: IP
               Limit: ${self:custom.registrationWAF.rateLimit, 500}
+              ScopeDownStatement: # Scope rate limiting to 'api' requests
+                # Documentation: https://docs.aws.amazon.com/waf/latest/developerguide/waf-bot-control-example-scope-down-login.html
+                ByteMatchStatement:
+                  SearchString: "api"
+                  FieldToMatch:
+                    UriPath: {}
+                  TextTransformations:
+                    - Priority: 0
+                      Type: NONE
+                  PositionalConstraint: CONTAINS
           VisibilityConfig:
             SampledRequestsEnabled: true
             CloudWatchMetricsEnabled: true
@@ -33,10 +43,37 @@ Resources:
             ManagedRuleGroupStatement:
               VendorName: "AWS"
               Name: "AWSManagedRulesBotControlRuleSet"
+              ManagedRuleGroupConfigs:
+                - AWSManagedRulesBotControlRuleSet:
+                    InspectionLevel: COMMON
+              RuleActionOverrides:
+                - Name: "SignalNonBrowserUserAgent"
+                  ActionToUse:
+                    Count: {}
           VisibilityConfig:
             SampledRequestsEnabled: true
             CloudWatchMetricsEnabled: true
             MetricName: "AWS-BotControl-Metric"
+        - Name: "Allow-Synthetic_Canary"
+          # Documentation: https://docs.aws.amazon.com/waf/latest/developerguide/waf-bot-control-example-user-agent-exception.html
+          Priority: 2
+          Statement:
+            NotStatement:
+              Statement:
+                RegexMatchStatement:
+                  RegexString: "arn:aws:synthetics:us-east-1:\\d+:canary"
+                  FieldToMatch:
+                    SingleHeader:
+                      Name: "user-agent"
+                  TextTransformations:
+                    - Priority: 0
+                      Type: NONE
+          Action:
+            Block: {}
+          VisibilityConfig:
+            SampledRequestsEnabled: true
+            CloudWatchMetricsEnabled: true
+            MetricName: "Allow-Synthetic_Canary"
   WAFRegionalWebACLAssoc:
     Type: "AWS::WAFv2::WebACLAssociation"
     Properties:

--- a/main/solution/post-deployment/config/infra/registrationWAF.yml
+++ b/main/solution/post-deployment/config/infra/registrationWAF.yml
@@ -58,18 +58,16 @@ Resources:
           # Documentation: https://docs.aws.amazon.com/waf/latest/developerguide/waf-bot-control-example-user-agent-exception.html
           Priority: 2
           Statement:
-            NotStatement:
-              Statement:
-                RegexMatchStatement:
-                  RegexString: "arn:aws:synthetics:us-east-1:\\d+:canary"
-                  FieldToMatch:
-                    SingleHeader:
-                      Name: "user-agent"
-                  TextTransformations:
-                    - Priority: 0
-                      Type: NONE
+            RegexMatchStatement:
+              RegexString: "arn:aws:synthetics:us-east-1:\\d+:canary"
+              FieldToMatch:
+                SingleHeader:
+                  Name: "user-agent"
+              TextTransformations:
+                - Priority: 0
+                  Type: NONE
           Action:
-            Block: {}
+            Allow: {}
           VisibilityConfig:
             SampledRequestsEnabled: true
             CloudWatchMetricsEnabled: true

--- a/main/solution/post-deployment/config/infra/registrationWAF.yml
+++ b/main/solution/post-deployment/config/infra/registrationWAF.yml
@@ -34,29 +34,9 @@ Resources:
             SampledRequestsEnabled: true
             CloudWatchMetricsEnabled: true
             MetricName: "HTTP-Flood-Prevent-Rule-Metric"
-        - Name: "AWS-BotControl"
-          # Documentation: https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-bot.html
-          Priority: 1
-          OverrideAction:
-            None: {}
-          Statement:
-            ManagedRuleGroupStatement:
-              VendorName: "AWS"
-              Name: "AWSManagedRulesBotControlRuleSet"
-              ManagedRuleGroupConfigs:
-                - AWSManagedRulesBotControlRuleSet:
-                    InspectionLevel: COMMON
-              RuleActionOverrides:
-                - Name: "SignalNonBrowserUserAgent"
-                  ActionToUse:
-                    Count: {}
-          VisibilityConfig:
-            SampledRequestsEnabled: true
-            CloudWatchMetricsEnabled: true
-            MetricName: "AWS-BotControl-Metric"
         - Name: "Allow-Synthetic_Canary"
           # Documentation: https://docs.aws.amazon.com/waf/latest/developerguide/waf-bot-control-example-user-agent-exception.html
-          Priority: 2
+          Priority: 1
           Statement:
             RegexMatchStatement:
               RegexString: "arn:aws:synthetics:us-east-1:\\d+:canary"
@@ -72,6 +52,22 @@ Resources:
             SampledRequestsEnabled: true
             CloudWatchMetricsEnabled: true
             MetricName: "Allow-Synthetic_Canary"
+        - Name: "AWS-BotControl"
+          # Documentation: https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-bot.html
+          Priority: 2
+          OverrideAction:
+            None: {}
+          Statement:
+            ManagedRuleGroupStatement:
+              VendorName: "AWS"
+              Name: "AWSManagedRulesBotControlRuleSet"
+              ManagedRuleGroupConfigs:
+                - AWSManagedRulesBotControlRuleSet:
+                    InspectionLevel: COMMON
+          VisibilityConfig:
+            SampledRequestsEnabled: true
+            CloudWatchMetricsEnabled: true
+            MetricName: "AWS-BotControl-Metric"
   WAFRegionalWebACLAssoc:
     Type: "AWS::WAFv2::WebACLAssociation"
     Properties:

--- a/main/solution/post-deployment/config/infra/registrationWAF.yml
+++ b/main/solution/post-deployment/config/infra/registrationWAF.yml
@@ -23,7 +23,7 @@ Resources:
               ScopeDownStatement: # Scope rate limiting to 'api' requests
                 # Documentation: https://docs.aws.amazon.com/waf/latest/developerguide/waf-bot-control-example-scope-down-login.html
                 ByteMatchStatement:
-                  SearchString: "api"
+                  SearchString: "/api"
                   FieldToMatch:
                     UriPath: {}
                   TextTransformations:

--- a/main/solution/post-deployment/serverless.yml
+++ b/main/solution/post-deployment/serverless.yml
@@ -71,7 +71,7 @@ custom:
   registrationWAF:
     albExportName: "${self:custom.settings.awsRegionShortName}-${self:custom.settings.solutionName}-LoadBalancerFullName"
     name: "${self:custom.settings.awsRegionShortName}-${self:custom.settings.solutionName}-WAF"
-    rateLimit: 4000 # Per ip, per 5 minutes
+    rateLimit: 1000 # Per ip, per 5 minutes
 
 functions: ${file(./config/infra/functions.yml)}
 


### PR DESCRIPTION
- Updates the WAF to allow Canary bot traffic.
- Updates the WAF to scope down the rate limit to `/api` requests.
- Reduces rate lmit on `/api` request to 1000.
  - Reduced because of scope down: Most requests on the SWB page are static content requests, so a low rate for just pure `/api` requests seems reasonable.

Checklist:
- [X] Have you successfully deployed to an AWS account with your changes?

----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.