### PR TITLE
Decouple register button from the rest of addon-custom package

### DIFF
--- a/addons/addon-base-ui/packages/base-ui/src/helpers/settings.js
+++ b/addons/addon-base-ui/packages/base-ui/src/helpers/settings.js
@@ -30,10 +30,10 @@ const branding = {
     title: process.env.REACT_APP_USER_REGISTRATION_TITLE,
     summary: process.env.REACT_APP_USER_REGISTRATION_SUMMARY,
     success: process.env.REACT_APP_USER_REGISTRATION_SUCCESS,
-    loginWarning: process.env.REACT_APP_USER_REGISTRATION_LOGIN_WARNING,
   },
   main: {
     title: process.env.REACT_APP_BRAND_MAIN_TITLE,
+    loginWarning: process.env.REACT_APP_LOGIN_WARNING,
   },
   page: {
     title: process.env.REACT_APP_BRAND_PAGE_TITLE,

--- a/addons/addon-base-ui/packages/base-ui/src/models/authentication/AuthenticationProviderPublicConfigsStore.js
+++ b/addons/addon-base-ui/packages/base-ui/src/models/authentication/AuthenticationProviderPublicConfigsStore.js
@@ -19,6 +19,8 @@ import { BaseStore } from '../BaseStore';
 import { getAuthenticationProviderPublicConfigs } from '../../helpers/api';
 import AuthenticationProviderPublicConfig from './AuthenticationProviderPublicConfig';
 
+const nativeUserPool = 'cognito_user_pool';
+
 const AuthenticationProviderPublicConfigsStore = BaseStore.named('AuthenticationProviderPublicConfigsStore')
   .props({
     authenticationProviderPublicConfigs: types.optional(types.array(AuthenticationProviderPublicConfig), []),
@@ -65,7 +67,10 @@ const AuthenticationProviderPublicConfigsStore = BaseStore.named('Authentication
 
       return result;
     },
-
+    get nativeUserPool() {
+      const configs = self.authenticationProviderPublicConfigs || [];
+      return configs.find(({ type }) => type === nativeUserPool) || {};
+    },
     toAuthenticationProviderFromId(authenticationProviderId) {
       return _.find(self.authenticationProviderPublicConfigs, { id: authenticationProviderId });
     },

--- a/addons/addon-custom/packages/main/package.json
+++ b/addons/addon-custom/packages/main/package.json
@@ -9,6 +9,7 @@
     "@aws-ee/base-services": "workspace:*",
     "@aws-ee/base-services-container": "workspace:*",
     "aws-sdk": "^2.1000.0",
+    "dompurify": "^2.4.3",
     "lodash": "^4.17.21",
     "mobx": "^5.15.4",
     "mobx-react": "^6.1.7",

--- a/addons/addon-custom/packages/main/src/extend/withAuth.js
+++ b/addons/addon-custom/packages/main/src/extend/withAuth.js
@@ -13,6 +13,7 @@
  *  permissions and limitations under the License.
  */
 import React from 'react';
+import _ from 'lodash';
 import { inject, observer } from 'mobx-react';
 import { withRouter, Link } from 'react-router-dom';
 import { Button } from 'semantic-ui-react';
@@ -39,18 +40,20 @@ function RegisterLogin(enableCustomRegister) {
 
     return (
       <>
-        {enableCustomRegister && <Button
-          data-testid="login"
-          type="submit"
-          color="blue"
-          fluid
-          basic
-          size="large"
-          className="mb2"
-          onClick={handleRegister}
-        >
-          Register
-        </Button>}
+        {enableCustomRegister && (
+          <Button
+            data-testid="login"
+            type="submit"
+            color="blue"
+            fluid
+            basic
+            size="large"
+            className="mb2"
+            onClick={handleRegister}
+          >
+            Register
+          </Button>
+        )}
         <Link to="/legal">Terms of Service</Link>
         <br />
         {branding.main.loginWarning}
@@ -106,10 +109,7 @@ class AuthWrapper extends React.Component {
   }
 }
 
-const WrapperComp = inject(
-  'app',
-  'authenticationProviderPublicConfigsStore'
-)(withRouter(observer(AuthWrapper)));
+const WrapperComp = inject('app', 'authenticationProviderPublicConfigsStore')(withRouter(observer(AuthWrapper)));
 
 function withAuth(Comp) {
   return function component(props) {

--- a/addons/addon-custom/packages/main/src/extend/withAuth.js
+++ b/addons/addon-custom/packages/main/src/extend/withAuth.js
@@ -30,7 +30,6 @@ const noAuthPaths = [
   { path: '/register', component: Register },
   { path: '/register-confirmation', component: Register },
 ];
-const nativeUserPool = 'cognito_user_pool';
 
 function RegisterLogin(enableCustomRegister) {
   function RegisterButton(selfRef) {
@@ -75,8 +74,7 @@ class AuthWrapper extends React.Component {
   }
 
   enableCustomRegister() {
-    const configs = _.get(this.appContext, 'authenticationProviderPublicConfigsStore.authenticationProviderPublicConfigs', []);
-    const nativeUserPoolConfig = configs.find(({ type }) => type === nativeUserPool) || {};
+    const nativeUserPoolConfig = this.props.authenticationProviderPublicConfigsStore.nativeUserPool;
     return _.get(nativeUserPoolConfig, 'customRegister', false);
   }
 
@@ -108,7 +106,10 @@ class AuthWrapper extends React.Component {
   }
 }
 
-const WrapperComp = inject('app')(withRouter(observer(AuthWrapper)));
+const WrapperComp = inject(
+  'app',
+  'authenticationProviderPublicConfigsStore'
+)(withRouter(observer(AuthWrapper)));
 
 function withAuth(Comp) {
   return function component(props) {

--- a/addons/addon-custom/packages/main/src/extend/withAuth.js
+++ b/addons/addon-custom/packages/main/src/extend/withAuth.js
@@ -30,8 +30,9 @@ const noAuthPaths = [
   { path: '/register', component: Register },
   { path: '/register-confirmation', component: Register },
 ];
+const nativeUserPool = 'cognito_user_pool';
 
-function RegisterLogin() {
+function RegisterLogin(enableCustomRegister) {
   function RegisterButton(selfRef) {
     function handleRegister() {
       gotoFn(selfRef)('/register');
@@ -39,7 +40,7 @@ function RegisterLogin() {
 
     return (
       <>
-        <Button
+        {enableCustomRegister && <Button
           data-testid="login"
           type="submit"
           color="blue"
@@ -50,10 +51,10 @@ function RegisterLogin() {
           onClick={handleRegister}
         >
           Register
-        </Button>
+        </Button>}
         <Link to="/legal">Terms of Service</Link>
         <br />
-        {branding.register.loginWarning}
+        {branding.main.loginWarning}
       </>
     );
   }
@@ -73,6 +74,12 @@ class AuthWrapper extends React.Component {
     return <Comp {...props} location={location} />;
   }
 
+  enableCustomRegister() {
+    const configs = _.get(this.appContext, 'authenticationProviderPublicConfigsStore.authenticationProviderPublicConfigs', []);
+    const nativeUserPoolConfig = configs.find(({ type }) => type === nativeUserPool) || {};
+    return _.get(nativeUserPoolConfig, 'customRegister', false);
+  }
+
   render() {
     const { app, location } = this.props;
     if (app.userAuthenticated) {
@@ -89,7 +96,7 @@ class AuthWrapper extends React.Component {
       gotoFn(this)('/');
     }
 
-    return RegisterLogin();
+    return RegisterLogin(this.enableCustomRegister());
   }
 
   // private utility methods

--- a/addons/addon-custom/packages/main/src/parts/Register.js
+++ b/addons/addon-custom/packages/main/src/parts/Register.js
@@ -38,7 +38,7 @@ class Register extends React.Component {
       };
       this.user = {};
       this.terms = termsState.unset;
-      this.termsModalButton = { focus: () => { } };
+      this.termsModalButton = { focus: () => {} };
     });
     this.registerFormFields = getRegisterFormFields();
   }
@@ -65,13 +65,13 @@ class Register extends React.Component {
   }
 
   renderHTML(content) {
-    const clean_content = DOMPurify.sanitize(content, { USE_PROFILES: { html: true } });
+    const cleanContent = DOMPurify.sanitize(content, { USE_PROFILES: { html: true } });
 
     // This method sets html from a string. We're pulling this from the config file made by
     // an approved admin, and we're sanitizing using dompurify package.
     // https://reactjs.org/docs/dom-elements.html#dangerouslysetinnerhtml
     // eslint-disable-next-line react/no-danger
-    return <div dangerouslySetInnerHTML={{ __html: clean_content }} />;
+    return <div dangerouslySetInnerHTML={{ __html: cleanContent }} />;
   }
 
   setTerms(terms) {

--- a/addons/addon-custom/packages/main/src/parts/Register.js
+++ b/addons/addon-custom/packages/main/src/parts/Register.js
@@ -4,6 +4,7 @@ import { observable, action, decorate, runInAction } from 'mobx';
 import { inject, observer } from 'mobx-react';
 import { withRouter } from 'react-router-dom';
 import { Form, Container, Grid, Dimmer, Loader, Header, Segment, Image, Label, Icon } from 'semantic-ui-react';
+import * as DOMPurify from 'dompurify';
 
 import { gotoFn } from '@aws-ee/base-ui/dist/helpers/routing';
 import { branding } from '@aws-ee/base-ui/dist/helpers/settings';
@@ -37,7 +38,7 @@ class Register extends React.Component {
       };
       this.user = {};
       this.terms = termsState.unset;
-      this.termsModalButton = { focus: () => {} };
+      this.termsModalButton = { focus: () => { } };
     });
     this.registerFormFields = getRegisterFormFields();
   }
@@ -64,11 +65,13 @@ class Register extends React.Component {
   }
 
   renderHTML(content) {
-    // This method sets html from a string. Because we're pulling this from the config file made by
-    // an approved admin, we know the value is safe so there is no danger in using it directly below.
+    const clean_content = DOMPurify.sanitize(content, { USE_PROFILES: { html: true } });
+
+    // This method sets html from a string. We're pulling this from the config file made by
+    // an approved admin, and we're sanitizing using dompurify package.
     // https://reactjs.org/docs/dom-elements.html#dangerouslysetinnerhtml
     // eslint-disable-next-line react/no-danger
-    return <div dangerouslySetInnerHTML={{ __html: content }} />;
+    return <div dangerouslySetInnerHTML={{ __html: clean_content }} />;
   }
 
   setTerms(terms) {

--- a/addons/addon-custom/packages/main/src/parts/Terms.js
+++ b/addons/addon-custom/packages/main/src/parts/Terms.js
@@ -1,16 +1,28 @@
 import React from 'react';
 import { Header } from 'semantic-ui-react';
+import * as DOMPurify from 'dompurify';
 
 import tos from '../../data/terms';
 
 const readableStyle = { fontSize: 'max(12pt, 1.2rem)', fontFamily: 'Calibri' };
 
 class Terms extends React.PureComponent {
+  renderHTML(content) {
+    const clean_content = DOMPurify.sanitize(content, { USE_PROFILES: { html: true } });
+
+    // This method sets html from a string. We're pulling this from the config file made by
+    // an approved admin, and we're sanitizing using dompurify package.
+    // https://reactjs.org/docs/dom-elements.html#dangerouslysetinnerhtml
+    // eslint-disable-next-line react/no-danger
+    return <div dangerouslySetInnerHTML={{ __html: clean_content }} style={readableStyle} />;
+  }
+
   render() {
     const populatedTerms = Object.entries(tos[0].fields).reduce(
       (terms, [field, value]) => terms.replaceAll(`{${field.toUpperCase()}}`, value),
       tos[0].terms,
     ).replaceAll('{HOSTNAME}', window.location.hostname);
+
     const date = new Date(tos[0].date).toLocaleDateString('en-US', {
       weekday: 'long',
       year: 'numeric',
@@ -18,17 +30,12 @@ class Terms extends React.PureComponent {
       day: 'numeric',
     });
 
-    // This method sets html from a string. Because we're pulling this from the config file made by
-    // an approved admin, we know the value is safe so there is no danger in using it directly below.
-    // https://reactjs.org/docs/dom-elements.html#dangerouslysetinnerhtml
-    // eslint-disable-next-line react/no-danger
-    const content = <div dangerouslySetInnerHTML={{ __html: populatedTerms }} style={readableStyle} />;
     return (
       <div id="tos">
         <Header as="h3" textAlign="center">
           Terms as of {date}
         </Header>
-        {content}
+        {this.renderHTML(populatedTerms)}
       </div>
     );
   }

--- a/addons/addon-custom/packages/main/src/parts/Terms.js
+++ b/addons/addon-custom/packages/main/src/parts/Terms.js
@@ -8,20 +8,19 @@ const readableStyle = { fontSize: 'max(12pt, 1.2rem)', fontFamily: 'Calibri' };
 
 class Terms extends React.PureComponent {
   renderHTML(content) {
-    const clean_content = DOMPurify.sanitize(content, { USE_PROFILES: { html: true } });
+    const cleanContent = DOMPurify.sanitize(content, { USE_PROFILES: { html: true } });
 
     // This method sets html from a string. We're pulling this from the config file made by
     // an approved admin, and we're sanitizing using dompurify package.
     // https://reactjs.org/docs/dom-elements.html#dangerouslysetinnerhtml
     // eslint-disable-next-line react/no-danger
-    return <div dangerouslySetInnerHTML={{ __html: clean_content }} style={readableStyle} />;
+    return <div dangerouslySetInnerHTML={{ __html: cleanContent }} style={readableStyle} />;
   }
 
   render() {
-    const populatedTerms = Object.entries(tos[0].fields).reduce(
-      (terms, [field, value]) => terms.replaceAll(`{${field.toUpperCase()}}`, value),
-      tos[0].terms,
-    ).replaceAll('{HOSTNAME}', window.location.hostname);
+    const populatedTerms = Object.entries(tos[0].fields)
+      .reduce((terms, [field, value]) => terms.replaceAll(`{${field.toUpperCase()}}`, value), tos[0].terms)
+      .replaceAll('{HOSTNAME}', window.location.hostname);
 
     const date = new Date(tos[0].date).toLocaleDateString('en-US', {
       weekday: 'long',

--- a/addons/addon-custom/packages/main/src/parts/TermsModel.js
+++ b/addons/addon-custom/packages/main/src/parts/TermsModel.js
@@ -82,13 +82,17 @@ class TermsModal extends React.Component {
           <Modal.Actions>
             {acceptAction && declineAction ? (
               <>
-                <Button primary onClick={this.closeModal(acceptAction)}>Accept</Button>
+                <Button primary onClick={this.closeModal(acceptAction)}>
+                  Accept
+                </Button>
                 <Button onClick={logoutOnDecline ? this.handleLogout(declineAction) : this.closeModal(declineAction)}>
                   Decline
                 </Button>
               </>
             ) : (
-              <Button primary onClick={this.closeModal()}>Close</Button>
+              <Button primary onClick={this.closeModal()}>
+                Close
+              </Button>
             )}
           </Modal.Actions>
         </Modal>

--- a/addons/addon-custom/packages/main/src/plugins/app-component-plugin.js
+++ b/addons/addon-custom/packages/main/src/plugins/app-component-plugin.js
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import App from '../parts/App';
 
 // eslint-disable-next-line no-unused-vars, consistent-return

--- a/addons/addon-custom/packages/main/src/plugins/app-component-plugin.js
+++ b/addons/addon-custom/packages/main/src/plugins/app-component-plugin.js
@@ -1,17 +1,9 @@
 import _ from 'lodash';
 import App from '../parts/App';
 
-const nativeUserPool = 'cognito_user_pool';
-
 // eslint-disable-next-line no-unused-vars, consistent-return
 function getAppComponent({ location, appContext }) {
-  const configs = _.get(appContext, 'authenticationProviderPublicConfigsStore.authenticationProviderPublicConfigs', []);
-  const nativeUserPoolConfig = configs.find(({ type }) => type === nativeUserPool) || {};
-  const customRegister = _.get(nativeUserPoolConfig, 'customRegister', false);
-
-  if (customRegister) {
-    return App;
-  }
+  return App;
 }
 
 export default { getAppComponent };

--- a/addons/addon-custom/packages/main/src/plugins/routes-plugin.js
+++ b/addons/addon-custom/packages/main/src/plugins/routes-plugin.js
@@ -29,11 +29,7 @@ import Register from '../parts/Register';
  */
 // eslint-disable-next-line no-unused-vars
 function registerRoutes(routesMap, { location, appContext }) {
-  const routes = new Map([
-    ...routesMap,
-    ['/register', withAuth(Register)],
-    ['/legal', withAuth(TermsPage)]
-  ]);
+  const routes = new Map([...routesMap, ['/register', withAuth(Register)], ['/legal', withAuth(TermsPage)]]);
   return routes;
 }
 

--- a/main/config/settings/example.yml
+++ b/main/config/settings/example.yml
@@ -155,4 +155,4 @@ HostedZoneId: 'Z02455261RJ9QQPVHFZGA'
 #userRegistrationTitle: "WELCOME TO SERVICE WORKBENCH"
 #userRegistrationSummary: "<p>Service Workbench provides a self-service, three-click, on-demand service for researchers to build research environments in minutes without needing cloud infrastructure knowledge. Fill out the form below to create your account on Service Workbench hosted on AWS.</p>"
 #userRegistrationSuccess: "<p>Your Service Workbench account has been successfully created. What you should expect next:</p><ol><li>The Service Workbench administrator will review your account.</li><li>Once your account is activated, you can login to Service Workbench and start your research.</li></ol>"
-#userRegistrationLoginWarning: "WARNING: You are entering a secure environment."
+#loginWarning: "WARNING: You are entering a secure environment."

--- a/main/solution/ui/config/environment/env-template.yml
+++ b/main/solution/ui/config/environment/env-template.yml
@@ -24,7 +24,7 @@ REACT_APP_ENABLE_FLOW_LOGS: ${self:custom.settings.enableFlowLogs}
 REACT_APP_USER_REGISTRATION_TITLE: ${self:custom.settings.userRegistrationTitle}
 REACT_APP_USER_REGISTRATION_SUMMARY: ${self:custom.settings.userRegistrationSummary}
 REACT_APP_USER_REGISTRATION_SUCCESS: ${self:custom.settings.userRegistrationSuccess}
-REACT_APP_USER_REGISTRATION_LOGIN_WARNING: ${self:custom.settings.userRegistrationLoginWarning}
+REACT_APP_LOGIN_WARNING: ${self:custom.settings.loginWarning}
 
 # ========================================================================
 # Overrides for .env.local

--- a/main/solution/ui/config/settings/.defaults.yml
+++ b/main/solution/ui/config/settings/.defaults.yml
@@ -33,4 +33,4 @@ enableCustomRegistration: false
 userRegistrationTitle: "WELCOME TO SERVICE WORKBENCH"
 userRegistrationSummary: "<p>Service Workbench provides a self-service, three-click, on-demand service for researchers to build research environments in minutes without needing cloud infrastructure knowledge. Fill out the form below to create your account on Service Workbench hosted on AWS.</p>"
 userRegistrationSuccess: "<p>Your Service Workbench account has been successfully created. What you should expect next:</p><ol><li>The Service Workbench administrator will review your account.</li><li>Once your account is activated, you can login to Service Workbench and start your research.</li></ol>"
-userRegistrationLoginWarning: ""
+loginWarning: ""

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2037,6 +2037,7 @@ importers:
       '@babel/preset-react': ^7.8.3
       aws-sdk: ^2.1000.0
       babel-eslint: ^10.0.3
+      dompurify: ^2.4.3
       enzyme: ^3.11.0
       enzyme-adapter-react-16: ^1.15.2
       eslint: ^6.8.0
@@ -2070,6 +2071,7 @@ importers:
       '@aws-ee/base-controllers': link:../../../addon-base-rest-api/packages/base-controllers
       '@aws-ee/base-services-container': link:../../../addon-base/packages/services-container
       aws-sdk: 2.1015.0
+      dompurify: 2.4.3
       lodash: 4.17.21
       mobx: 5.15.4
       mobx-react: 6.2.2_mobx@5.15.4+react@16.13.1
@@ -11384,6 +11386,10 @@ packages:
     dependencies:
       domelementtype: 1.3.1
     dev: true
+
+  /dompurify/2.4.3:
+    resolution: {integrity: sha512-q6QaLcakcRjebxjg8/+NP+h0rPfatOgOzc46Fst9VAA3jF2ApfKBNKMzdP4DYTqtUMXSCd5pRS/8Po/OmoCHZQ==}
+    dev: false
 
   /domutils/1.5.1:
     resolution: {integrity: sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=}


### PR DESCRIPTION
- Adds new nativeUserPool method to public config store model.
- Purifies data sent to dangerouslySetInnerHTML in custom-addon, just in case.
- Fixes misc leftover lint issues in addon-custom package.

Checklist:
- [X] Have you successfully deployed to an AWS account with your changes?
- [X] Have you successfully tested with your changes locally?

----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.