### PR TITLE
Bugfix/data source update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file. As our fork has diverged from AWS SWB mainline branch, we are noting the SWB version and the lab version together, as <swb version>\_<lab version>, starting from SWB mainline, 5.0.0.
 
+## [5.0.0_1.0.2](https://github.com/hms-dbmi/service-workbench-on-aws/compare/v5.0.0_1.0.1...v5.0.0_1.0.2) (04/06/2023)
+- Implement data source/study bugfix to only update users effected by permission changes instead of all users on the study.
+    - Users who had their permissions changes will need to be notified and will have to re-launch any effected workspaces.
+- Clone SWB example repos on workspace init.
+
 ## [5.0.0_1.0.1](https://github.com/hms-dbmi/service-workbench-on-aws/compare/v5.0.0_1.0.0...v5.0.0_1.0.1) (03/03/2023)
 
 - Remove create study UI functionality and 'My Studies' tab from Studies page.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file. As our fork has diverged from AWS SWB mainline branch, we are noting the SWB version and the lab version together, as <swb version>\_<lab version>, starting from SWB mainline, 5.0.0.
 
 ## [5.0.0_1.0.2](https://github.com/hms-dbmi/service-workbench-on-aws/compare/v5.0.0_1.0.1...v5.0.0_1.0.2) (04/06/2023)
-- Implement data source/study bugfix to only update users effected by permission changes instead of all users on the study.
+- Implement data source/study bugfix to only update users affected by permission changes instead of all users on the study.
     - Users who had their permissions changes will need to be notified and will have to re-launch any effected workspaces.
 - Clone SWB example repos on workspace init.
 

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/studies/StudyPermissionsStore.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/studies/StudyPermissionsStore.js
@@ -65,7 +65,9 @@ const StudyPermissionsStore = BaseStore.named('StudyPermissionsStore')
           // Set selected users as "usersToAdd" (API is idempotent)
           // And remove staleUserIds from usersToAdd list
           updateRequest.usersToAdd.push(
-            ..._.differenceWith(selectedUserIds[type], self.studyPermissions[`${type}Users`], _.isEqual).map(userToRequestFormat),
+            ..._.differenceWith(selectedUserIds[type], self.studyPermissions[`${type}Users`], _.isEqual).map(
+              userToRequestFormat,
+            ),
           );
 
           // Set removed users as "usersToRemove"

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/studies/StudyPermissionsStore.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/studies/StudyPermissionsStore.js
@@ -65,7 +65,7 @@ const StudyPermissionsStore = BaseStore.named('StudyPermissionsStore')
           // Set selected users as "usersToAdd" (API is idempotent)
           // And remove staleUserIds from usersToAdd list
           updateRequest.usersToAdd.push(
-            ..._.differenceWith(selectedUserIds[type], staleUserIds[type], _.isEqual).map(userToRequestFormat),
+            ..._.differenceWith(selectedUserIds[type], self.studyPermissions[`${type}Users`], _.isEqual).map(userToRequestFormat),
           );
 
           // Set removed users as "usersToRemove"

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/studies/StudyPermissionsStore.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/studies/StudyPermissionsStore.js
@@ -63,7 +63,7 @@ const StudyPermissionsStore = BaseStore.named('StudyPermissionsStore')
           const userToRequestFormat = uid => ({ uid, permissionLevel: type });
 
           // Set selected users as "usersToAdd" (API is idempotent)
-          // And remove staleUserIds from usersToAdd list
+          // And remove users who don't need updated from usersToAdd list
           updateRequest.usersToAdd.push(
             ..._.differenceWith(selectedUserIds[type], self.studyPermissions[`${type}Users`], _.isEqual).map(
               userToRequestFormat,


### PR DESCRIPTION
Update api request from UI to only include users who had their permissions changed. Api then updates that user by deleting the user permissions and then re-adding them. Reducing this update list stops users who already are on the study, who are not getting updated, to retain their original permissions.

Checklist:
- [X] Have you successfully deployed to an AWS account with your changes?

----

Ticket ID: ALS-4338

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.