### PR TITLE
Feature/workspace filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file. As our fork has diverged from AWS SWB mainline branch, we are noting the SWB version and the lab version together, as <swb version>\_<lab version>, starting from SWB mainline, 5.0.0.
 
+## [5.0.0_1.1.0](https://github.com/hms-dbmi/service-workbench-on-aws/compare/v5.0.0_1.0.3...v5.0.0_1.1.0) (07/05/2023)
+- Add search field to normal workspace view.
+- Add an advanced workspace table view with sorting & filtering.
+- Set workspace CFT info as default tab on workspace detail page.
+- Hide termination toggle on detail view for workspaces that can't be terminated.
 
 ## [5.0.0_1.0.4](https://github.com/hms-dbmi/service-workbench-on-aws/compare/v5.0.0_1.0.3...v5.0.0_1.0.4) (06/13/2023)
 - Add S3 GetObject and List permission to access embed data for workspaces.

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/environments-sc/advanced/ScEnvView.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/environments-sc/advanced/ScEnvView.js
@@ -1,0 +1,70 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+import { types } from 'mobx-state-tree';
+import { cloneDeep } from 'lodash';
+
+const ORDER = { DESC: 'desc', ASC: 'asc' };
+const VIEW = { ADVANCED: 'Advanced', NORMAL: 'Normal' };
+
+const Filter = types.model({
+  key: types.string,
+  value: types.array(types.string),
+  icon: types.string,
+  match: types.string,
+});
+
+const Sort = types.model({
+  key: types.string,
+  order: types.enumeration('order', [ORDER.DESC, ORDER.ASC]),
+});
+
+const ScEnvView = types
+  .model('ScEnvView', {
+    activeFilters: types.optional(types.array(Filter), []),
+    activeMode: types.optional(types.string, 'and'),
+    sort: types.optional(Sort, { key: 'createdAt', order: ORDER.DESC }),
+    view: types.optional(types.enumeration('view', [VIEW.ADVANCED, VIEW.NORMAL]), VIEW.NORMAL),
+  })
+  .actions(self => ({
+    setFilters(filters = [], mode = 'or') {
+      self.activeFilters = cloneDeep(filters);
+      self.activeMode = mode;
+    },
+    setSort(key) {
+      if (key === self.sort.key) {
+        self.sort.order = self.sort.order === ORDER.ASC ? ORDER.DESC : ORDER.ASC;
+      } else {
+        self.sort.key = key;
+        self.sort.order = ORDER.ASC;
+      }
+    },
+    toggleView() {
+      self.view = self.view === VIEW.ADVANCED ? VIEW.NORMAL : VIEW.ADVANCED;
+    },
+  }))
+  .views(self => ({
+    get filters() {
+      return self.activeFilters;
+    },
+    get mode() {
+      return self.activeMode;
+    },
+  }));
+
+function registerContextItems(appContext) {
+  appContext.ScEnvView = ScEnvView.create({}, appContext);
+}
+
+export { ScEnvView, registerContextItems, ORDER, VIEW };

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/ScEnvironmentDetailPage.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/ScEnvironmentDetailPage.js
@@ -189,11 +189,12 @@ class ScEnvironmentDetailPage extends React.Component {
       </Table.Row>
     );
     const isAdmin = this.userStore.isAdmin;
+    const canToggleLock = this.envsStore.canChangeState(env.id) && env.state.canTerminate;
 
     return (
       <Table definition>
         <Table.Body>
-          {isAdmin && renderRow('Termination Lock', this.renderTerminationLock(env))}
+          {isAdmin && canToggleLock && renderRow('Termination Lock', this.renderTerminationLock(env))}
           {renderRow('Status', this.renderStatus(env))}
           {renderRow('Owner', <By uid={env.createdBy} skipPrefix />)}
           {renderRow('Studies', studyCount === 0 ? 'No studies linked to this workspace' : studyIds.join(', '))}
@@ -304,7 +305,15 @@ class ScEnvironmentDetailPage extends React.Component {
       },
     ];
 
-    return <Tab className="mt4" menu={{ secondary: true, pointing: true }} renderActiveOnly panes={panes} />;
+    return (
+      <Tab
+        className="mt4"
+        menu={{ secondary: true, pointing: true }}
+        renderActiveOnly
+        panes={panes}
+        defaultActiveIndex="1"
+      />
+    );
   }
 
   renderCfnOutput(env) {

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/ScEnvsHeader.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/ScEnvsHeader.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import { Icon, Label, Header, Button } from 'semantic-ui-react';
+
+import { VIEW } from '../../models/environments-sc/advanced/ScEnvView';
+
+// expected props
+// - current, as number containing the total visible workspaces
+// - total, as number containing all environments
+// - isAdmin, as boolean
+// - provisionDisabled, as boolean
+// - onViewToggle
+// - onEnvCreate
+export default function EnvsHeader({
+  view = VIEW.NORMAL,
+  current,
+  total,
+  isAdmin = false,
+  provisionDisabled = false,
+  onViewToggle,
+  onEnvCreate,
+}) {
+  return (
+    <div className="mb3 flex">
+      <Header as="h3" className="color-grey mt1 mb0 flex-auto">
+        <Icon name="server" className="align-top" />
+        <Header.Content className="left-align">
+          Research Workspaces
+          {current !== total ? (
+            <Label circular>
+              {current}/{total}
+            </Label>
+          ) : (
+            <Label circular>{total}</Label>
+          )}
+        </Header.Content>
+      </Header>
+      {isAdmin && (
+        <Button
+          basic
+          content={view === VIEW.NORMAL ? VIEW.ADVANCED : VIEW.NORMAL}
+          icon="list alternate outline"
+          labelPosition="left"
+          onClick={onViewToggle}
+        />
+      )}
+      <div>
+        <Button
+          data-testid="create-workspace"
+          color="blue"
+          size="medium"
+          disabled={provisionDisabled}
+          basic
+          onClick={onEnvCreate}
+        >
+          Create Research Workspace
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/advanced/ActionButtons.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/advanced/ActionButtons.js
@@ -1,0 +1,70 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+import React, { useState } from 'react';
+import { Button, Modal } from 'semantic-ui-react';
+
+// expected props
+// - id
+// - terminationLocked, as boolean
+// - enabled, as { [action]: boolean }
+// - onAction(action, id)
+export default function ActionButtons({ id, pending = false, terminationLocked, can, onAction }) {
+  const [loading, setLoading] = useState(pending);
+
+  function handleAction(action, value) {
+    return async () => {
+      setLoading(true);
+      await onAction(action, value);
+      setLoading(false);
+    };
+  }
+
+  return (
+    <Button.Group size="mini" className="m1">
+      <Button icon="eye" onClick={handleAction('view', `/workspaces/id/${id}`)} />
+      {can.start && <Button icon="play circle" color="green" loading={loading} onClick={handleAction('start', id)} />}
+      {can.stop && <Button icon="stop circle" color="orange" loading={loading} onClick={handleAction('stop', id)} />}
+      {can.terminate &&
+        (terminationLocked ? (
+          <Button disabled icon="trash" color="red" loading={loading} />
+        ) : (
+          <Modal
+            trigger={<Button icon="trash" color="red" loading={loading} />}
+            header="Are you sure?"
+            content="This action can not be reverted."
+            actions={[
+              'Cancel',
+              {
+                key: 'terminate',
+                content: 'Terminate',
+                negative: true,
+                onClick: handleAction('terminate', id),
+              },
+            ]}
+            size="mini"
+          />
+        ))}
+      {can.lock && (
+        <Button
+          icon={terminationLocked ? 'unlock' : 'lock'}
+          color="teal"
+          loading={loading}
+          onClick={handleAction('toggleLock', id)}
+        />
+      )}
+    </Button.Group>
+  );
+}

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/advanced/CompactTable.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/advanced/CompactTable.js
@@ -1,0 +1,69 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+import React from 'react';
+import { Table, Icon } from 'semantic-ui-react';
+import TimeAgo from 'react-timeago';
+
+import { ORDER } from '../../../models/environments-sc/advanced/ScEnvView';
+
+const iconMap = {
+  [ORDER.ASC]: 'sort up',
+  [ORDER.DESC]: 'sort down',
+  none: 'sort',
+};
+
+// expected props
+// - columns, as array of { key, label }
+// - rows, as map of { [column]: value }
+// - onSort
+export default function CompactTable({ columns, rows, sort, onSort }) {
+  const sortedIcon = column => (column === sort.key ? iconMap[sort.order] : iconMap.none);
+  function handleSort(key) {
+    return () => onSort(key);
+  }
+
+  return (
+    <Table celled striped compact size="small">
+      <Table.Header>
+        <Table.Row key="header">
+          {columns.map(({ key, label, sortable = true }) =>
+            sortable ? (
+              <Table.HeaderCell key={`header-${key}`} onClick={handleSort(key)} className="cursor-pointer">
+                {label}
+                <Icon name={sortedIcon(key)} />
+              </Table.HeaderCell>
+            ) : (
+              <Table.HeaderCell key={`header-${key}`}>{label}</Table.HeaderCell>
+            ),
+          )}
+          <Table.HeaderCell key="header-actions">Actions</Table.HeaderCell>
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>
+        {rows.map(row => (
+          <Table.Row key={row.id}>
+            {columns.map(({ key, type = 'string' }) => (
+              <Table.Cell key={`${row.id}-${key}`}>
+                {type === 'date' ? <TimeAgo date={row[key]} /> : row[key]}
+              </Table.Cell>
+            ))}
+            <Table.HeaderCell key={`${row.id}-actions`}>{row.actions}</Table.HeaderCell>
+          </Table.Row>
+        ))}
+      </Table.Body>
+    </Table>
+  );
+}

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/advanced/FilterBox.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/advanced/FilterBox.js
@@ -1,0 +1,54 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+import React, { useState } from 'react';
+import { Icon, Accordion, Segment, Divider, Header } from 'semantic-ui-react';
+
+import FilterForm from './FilterForm';
+import FilterList from './FilterList';
+
+// expected props
+// - mode, as string of either 'or' or 'and'
+// - filters, as array of { key, value:[], match, icon }
+// - fields, as array of { key, icon, label, options }
+// - onNewFilter({ filters, mode })
+export default function FilterBox({ mode = 'or', filters = [], fields, onFilter }) {
+  const [active, setActive] = useState(false);
+
+  function toggleActive() {
+    return () => setActive(!active);
+  }
+
+  return (
+    <Segment color={active && 'blue'}>
+      <Accordion fluid>
+        <Accordion.Title index={0} active={active} onClick={toggleActive()}>
+          <Icon name="filter" />
+          Filters
+          <Icon name={active ? 'caret up' : 'caret down'} />
+          {!active && <FilterList mode={mode} filters={filters} />}
+        </Accordion.Title>
+        <Accordion.Content active={active}>
+          <FilterForm mode={mode} filters={filters} fields={fields} onFilter={onFilter} />
+          <Divider horizontal fitted className="cursor-pointer" onClick={toggleActive()}>
+            <Header as="h5">
+              <Icon name="caret up" className="mr0" />
+              Collapse
+            </Header>
+          </Divider>
+        </Accordion.Content>
+      </Accordion>
+    </Segment>
+  );
+}

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/advanced/FilterForm.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/advanced/FilterForm.js
@@ -1,0 +1,137 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+import React, { useState } from 'react';
+import _, { mapValues } from 'lodash';
+import { Button, Icon, Dropdown, Label, Form, Input } from 'semantic-ui-react';
+
+// expected props
+// - mode, as 'or' or 'and'
+// - onToggle(value)
+function ModeToggle({ mode, onToggle }) {
+  const orMode = mode === 'or';
+  const off = text => (
+    <Button onClick={() => onToggle(text)}>
+      <Icon name="circle outline" /> {text.toUpperCase()}
+    </Button>
+  );
+  const on = text => (
+    <Button primary>
+      <Icon name="check circle" /> {text.toUpperCase()}
+    </Button>
+  );
+
+  return (
+    <Button.Group className="mr1">
+      {orMode ? off('and') : on('and')}
+      {orMode ? on('or') : off('or')}
+    </Button.Group>
+  );
+}
+
+// expected props
+// - fields, as array of { key, icon, label, options }
+// - onChange({ fields, mode })
+export default function FilterForm({ mode, filters, fields, onFilter }) {
+  const [form, setForm] = useState(
+    filters.reduce((acc, { key, value, match }) => ({ ...acc, [key]: { value: [...value], match } }), {
+      name: { value: [] },
+      user: { value: [] },
+      project: { value: [] },
+      study: { value: [] },
+      type: { value: [] },
+      configType: { value: [] },
+      status: { value: [] },
+    }),
+  );
+
+  const iconsMap = _.reduce(fields, (acc, { key, icon }) => ({ ...acc, [key]: icon }), {});
+
+  /* eslint-disable no-unused-vars */
+  const getFiltersFromForm = formValues =>
+    Object.entries(formValues)
+      .filter(([key, { value }]) => value.length > 1 || value[0]) // remove empty objects
+      .map(([key, { value, match = 'exact' }]) => ({ key, value, icon: iconsMap[key], match })); // populate icons and default match
+  /* eslint-disable no-unused-vars */
+
+  function handleChange(key, match) {
+    return (e, { value }) => {
+      const newForm = { ...form, [key]: { value: Array.isArray(value) ? value : [value], match } };
+      onFilter({ filters: getFiltersFromForm(newForm), mode });
+      setForm(newForm);
+    };
+  }
+
+  function updateMode() {
+    return newMode => {
+      const newForm = mapValues(form, ({ value }) => ({ value: value.slice(0, 1) }));
+      onFilter({ filters: getFiltersFromForm(newForm), mode: newMode });
+      setForm(newForm);
+    };
+  }
+
+  return (
+    <Form>
+      <ModeToggle mode={mode} onToggle={updateMode()} />
+      {fields
+        .filter(({ filterable = true }) => filterable)
+        .map(({ key, icon, label, options }) => {
+          if (options) {
+            return (
+              <Input action key={key} labelPosition="left" className="mr1 mb1">
+                <Label>
+                  <Icon name={icon} />
+                  {label}:
+                </Label>
+                {mode === 'or' ? (
+                  <Dropdown
+                    selection
+                    search
+                    multiple
+                    options={options}
+                    value={form[key].value}
+                    onChange={handleChange(key, 'multiple')}
+                  />
+                ) : (
+                  <Dropdown
+                    selection
+                    search
+                    options={[{ text: <i>none</i>, value: '' }, ...options]}
+                    value={form[key].value[0]}
+                    onChange={handleChange(key, 'exact')}
+                  />
+                )}
+              </Input>
+            );
+          }
+          return (
+            <Input
+              key={key}
+              labelPosition="left"
+              className="mr1 mb1"
+              value={form[key].value[0]}
+              onChange={handleChange(key, 'partial')}
+            >
+              <Label>
+                <Icon name={icon} />
+                {label}:
+              </Label>
+              <input type="text" style={{ width: 'auto' }} />
+            </Input>
+          );
+        })}
+    </Form>
+  );
+}

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/advanced/FilterList.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/advanced/FilterList.js
@@ -1,0 +1,49 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+import React from 'react';
+import { Icon, Label } from 'semantic-ui-react';
+
+// expected props
+// - key
+// - value
+// - icon
+function Filter({ value, icon }) {
+  const filters = value.join(', ');
+
+  if (!filters) return <></>;
+
+  return (
+    <Label basic>
+      <Icon name={icon} /> {filters}
+    </Label>
+  );
+}
+
+// expected props
+// - mode, as 'or' or 'and'
+// - filters, as array of { key, value, icon }
+export default function FilterList({ mode, filters }) {
+  if (filters.length === 0) return <></>;
+
+  return (
+    <span className="ml2">
+      <Label basic>Mode: {mode.toUpperCase()}</Label>
+      {filters.map(({ key, value, icon }) => (
+        <Filter key={key} value={value} icon={icon} />
+      ))}
+    </span>
+  );
+}

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/advanced/ScEnvAdvancedList.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/advanced/ScEnvAdvancedList.js
@@ -1,0 +1,258 @@
+import React from 'react';
+import _ from 'lodash';
+import { decorate, computed, action, runInAction } from 'mobx';
+import { observer, inject } from 'mobx-react';
+import { withRouter } from 'react-router-dom';
+import { Container, Icon, Segment, Header } from 'semantic-ui-react';
+
+import { swallowError } from '@aws-ee/base-ui/dist/helpers/utils';
+import { gotoFn } from '@aws-ee/base-ui/dist/helpers/routing';
+import {
+  isStoreLoading,
+  isStoreEmpty,
+  isStoreNotEmpty,
+  isStoreError,
+  isStoreReady,
+} from '@aws-ee/base-ui/dist/models/BaseStore';
+import ErrorBox from '@aws-ee/base-ui/dist/parts/helpers/ErrorBox';
+import ProgressPlaceHolder from '@aws-ee/base-ui/dist/parts/helpers/BasicProgressPlaceholder';
+
+import CompactTable from './CompactTable';
+import FilterBox from './FilterBox';
+import ActionButtons from './ActionButtons';
+import EnvsHeader from '../ScEnvsHeader';
+
+const statusMap = [
+  { name: 'AVAILABLE', list: ['COMPLETED', 'TAINTED'] },
+  { name: 'STOPPED', list: ['STOPPED'] },
+  { name: 'PENDING', list: ['PENDING', 'TERMINATING', 'STARTING', 'STOPPING'] },
+  { name: 'ERRORED', list: ['FAILED', 'TERMINATING_FAILED', 'STARTING_FAILED', 'STOPPING_FAILED'] },
+  { name: 'TERMINATED', list: ['TERMINATED'] },
+];
+
+class ScEnvAdvancedList extends React.Component {
+  constructor(props) {
+    super(props);
+    runInAction(() => {
+      this.goto = gotoFn(this);
+    });
+  }
+
+  componentDidMount() {
+    window.scrollTo(0, 0);
+    swallowError(this.envsStore.load());
+    this.envsStore.startHeartbeat();
+
+    if (!isStoreReady(this.envTypesStore)) {
+      swallowError(this.envTypesStore.load());
+    }
+  }
+
+  get envTypesStore() {
+    return this.props.envTypesStore;
+  }
+
+  get envsStore() {
+    return this.props.scEnvironmentsStore;
+  }
+
+  get userDisplayName() {
+    return this.props.userDisplayName;
+  }
+
+  get viewStore() {
+    return this.props.ScEnvView;
+  }
+
+  userName(env) {
+    return this.props.userDisplayName.getLongDisplayName({ uid: env.createdBy });
+  }
+
+  workspaceName(env) {
+    return this.props.envTypesStore.getEnvType(env.envTypeId)?.name;
+  }
+
+  statusName(envStatus) {
+    return _.find(statusMap, ({ list }) => list.includes(envStatus))?.name || 'UNKNOWN';
+  }
+
+  canDoAction(env, actionType) {
+    return this.envsStore.canChangeState(env.id) && env.state[actionType];
+  }
+
+  getEnvFields(envs) {
+    const optionSets = envs.reduce(
+      (opts, env) => {
+        opts.user.add(this.userName(env));
+        opts.project.add(env.projectId);
+        env.studyIds.forEach(study => opts.study.add(study));
+        opts.type.add(this.workspaceName(env) || env.envTypeId);
+        opts.configType.add(env.envTypeConfigId);
+        return opts;
+      },
+      {
+        user: new Set(),
+        project: new Set(),
+        study: new Set(),
+        type: new Set(),
+        configType: new Set(),
+      },
+    );
+    const options = _.mapValues(optionSets, set => Array.from(set).map(option => ({ text: option, value: option })));
+    const statusOptions = statusMap.map(({ name }) => ({ text: name, value: name }));
+
+    const fields = [
+      { key: 'name', label: 'Name', icon: 'info' },
+      { key: 'user', label: 'Created By', icon: 'user', options: options.user },
+      { key: 'createdAt', label: 'Created At', icon: 'calendar alternate outline', type: 'date', filterable: false },
+      { key: 'project', label: 'Project', icon: 'suitcase', options: options.project },
+      { key: 'study', label: 'Studies', icon: 'database', options: options.study, sortable: false },
+      { key: 'type', label: 'Workspace Type', icon: 'laptop', options: options.type },
+      { key: 'configType', label: 'Workspace Config', icon: 'setting', options: options.configType },
+      { key: 'status', label: 'Status', icon: 'cloud', options: statusOptions },
+    ];
+    return fields;
+  }
+
+  getEnvs(envs, filters, sort) {
+    let envRow = _(envs).map(env => ({
+      id: env.id,
+      name: env.name,
+      user: this.userName(env),
+      createdAt: env.createdAt,
+      project: env.projectId,
+      study: env.studyIds?.join(', ') || 'none',
+      type: this.workspaceName(env) || env.envTypeId,
+      configType: env.envTypeConfigId,
+      status: this.statusName(env.status),
+      actions: (
+        <ActionButtons
+          id={env.id}
+          pending={this.statusName(env.status) === 'PENDING'}
+          terminationLocked={env.terminationLocked}
+          can={{
+            start: this.canDoAction(env, 'canStart'),
+            stop: this.canDoAction(env, 'canStop'),
+            terminate: this.canDoAction(env, 'canTerminate'),
+            lock: this.canDoAction(env, 'canTerminate'), // only allow lock/unlock if the instance can be terminated
+          }}
+          onAction={this.handleAction()}
+        />
+      ),
+    }));
+
+    if (filters.length > 0) {
+      const or = (list, predicate) => _.find(list, predicate);
+      const and = (list, predicate) => _.reduce(list, (acc, value) => acc && predicate(value), true);
+      const listMatcher = (A, b) => _.find(A, a => a === b);
+      const regexMatcher = (a, b) => new RegExp(_.escapeRegExp(a), 'i').test(b);
+
+      envRow = envRow.filter(env => {
+        const operator = this.viewStore.mode === 'or' ? or : and;
+        return operator(filters, ({ key, value, match }) => {
+          const matcher = match === 'partial' ? regexMatcher : listMatcher;
+          return matcher(value, env[key]);
+        });
+      });
+    }
+
+    return envRow.orderBy(sort.key, sort.order).value();
+  }
+
+  handleAction() {
+    const actionMap = {
+      start: this.envsStore.startScEnvironment,
+      stop: this.envsStore.stopScEnvironment,
+      terminate: this.envsStore.terminateScEnvironment,
+      toggleLock: this.envsStore.toggleScEnvironmentLock,
+      view: this.goto,
+    };
+    return (actionType, value) => actionMap[actionType](value);
+  }
+
+  handleFilter() {
+    return ({ filters, mode }) => runInAction(() => this.viewStore.setFilters(filters, mode));
+  }
+
+  handleSort() {
+    return key => runInAction(() => this.viewStore.setSort(key));
+  }
+
+  handleViewToggle() {
+    return () => runInAction(() => this.viewStore.toggleView());
+  }
+
+  handleCreateEnvironment() {
+    return event => {
+      event.preventDefault();
+      event.stopPropagation();
+
+      this.goto(`/workspaces/create`);
+    };
+  }
+
+  render() {
+    let content = null;
+
+    if (isStoreError(this.envsStore)) {
+      content = <ErrorBox error={this.envsStore.error} className="p0" />;
+    } else if (isStoreLoading(this.envsStore)) {
+      content = <ProgressPlaceHolder segmentCount={3} />;
+    } else if (isStoreEmpty(this.envsStore)) {
+      content = (
+        <Segment data-testid="workspaces" placeholder>
+          <Header icon className="color-grey">
+            <Icon name="server" />
+            No research workspaces
+            <Header.Subheader>To create a research workspace, click Create Research Workspace.</Header.Subheader>
+          </Header>
+        </Segment>
+      );
+    } else if (isStoreNotEmpty(this.envsStore)) {
+      const fields = this.getEnvFields(this.envsStore.list);
+      const tableColumns = fields.map(column => _.pick(column, ['key', 'label', 'sortable', 'type']));
+      const tableRows = this.getEnvs(this.envsStore.list, this.viewStore.filters, this.viewStore.sort);
+
+      content = (
+        <>
+          <EnvsHeader
+            current={tableRows.length}
+            total={this.envsStore.total}
+            view={this.viewStore.view}
+            isAdmin // We only get to this view if we're an admin, so this must be true
+            onViewToggle={this.handleViewToggle()}
+            onEnvCreate={this.handleCreateEnvironment()}
+          />
+          <FilterBox
+            mode={this.viewStore.mode}
+            filters={this.viewStore.filters}
+            fields={fields}
+            onFilter={this.handleFilter()}
+          />
+          <CompactTable sort={this.viewStore.sort} columns={tableColumns} rows={tableRows} onSort={this.handleSort()} />
+        </>
+      );
+    }
+
+    return <Container className="mt3 animated fadeIn">{content}</Container>;
+  }
+}
+
+// see https://medium.com/@mweststrate/mobx-4-better-simpler-faster-smaller-c1fbc08008da
+decorate(ScEnvAdvancedList, {
+  viewStore: computed,
+  envsStore: computed,
+  envTypesStore: computed,
+  userDisplayName: computed,
+  handleFilter: action,
+  handleSort: action,
+  handleViewToggle: action,
+  handleCreateEnvironment: action,
+});
+
+export default inject(
+  'ScEnvView',
+  'scEnvironmentsStore',
+  'userDisplayName',
+  'envTypesStore',
+)(withRouter(observer(ScEnvAdvancedList)));

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/parts/ScEnvironmentsFilterButtons.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/parts/ScEnvironmentsFilterButtons.js
@@ -17,7 +17,6 @@ import React from 'react';
 import { decorate, computed, action } from 'mobx';
 import { observer } from 'mobx-react';
 import { Button } from 'semantic-ui-react';
-import c from 'classnames';
 
 import { filterNames } from '../../../models/environments-sc/ScEnvironmentsStore';
 
@@ -60,15 +59,13 @@ class ScEnvironmentsFilterButtons extends React.Component {
     };
 
     return (
-      <div className={c('clearfix', this.props.className)}>
-        <Button.Group floated="right">
-          {_.map(_.keys(filterColorMap), name => (
-            <Button key={name} {...getAttrs(name)}>
-              {_.startCase(name)}
-            </Button>
-          ))}
-        </Button.Group>
-      </div>
+      <Button.Group className="ml2">
+        {_.map(_.keys(filterColorMap), name => (
+          <Button key={name} {...getAttrs(name)}>
+            {_.startCase(name)}
+          </Button>
+        ))}
+      </Button.Group>
     );
   }
 }

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments/EnvironmentsList.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments/EnvironmentsList.js
@@ -14,9 +14,43 @@
  */
 
 import React from 'react';
+import { decorate, observable, runInAction } from 'mobx';
+import { observer, inject } from 'mobx-react';
 
 import { enableBuiltInWorkspaces } from '../../helpers/settings';
 import BuiltIntEnvironmentsList from '../environments-builtin/EnvironmentsList';
 import ScEnvironmentsList from '../environments-sc/ScEnvironmentsList';
+import ScEnvAdvancedList from '../environments-sc/advanced/ScEnvAdvancedList';
 
-export default () => (enableBuiltInWorkspaces ? <BuiltIntEnvironmentsList /> : <ScEnvironmentsList />);
+import { VIEW } from '../../models/environments-sc/advanced/ScEnvView';
+
+class EnvironmentsList extends React.Component {
+  constructor(props) {
+    super(props);
+    runInAction(() => {
+      this.compact = false;
+    });
+  }
+
+  get envsStore() {
+    return this.props.scEnvironmentsStore;
+  }
+
+  get viewStore() {
+    return this.props.ScEnvView || VIEW.NORMAL;
+  }
+
+  render() {
+    if (this.viewStore.view === VIEW.ADVANCED) {
+      return <ScEnvAdvancedList />;
+    }
+    return enableBuiltInWorkspaces ? <BuiltIntEnvironmentsList /> : <ScEnvironmentsList />;
+  }
+}
+
+// see https://medium.com/@mweststrate/mobx-4-better-simpler-faster-smaller-c1fbc08008da
+decorate(EnvironmentsList, {
+  compact: observable,
+});
+
+export default inject('ScEnvView', 'scEnvironmentsStore')(observer(EnvironmentsList));

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments/EnvironmentsList.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments/EnvironmentsList.js
@@ -32,10 +32,6 @@ class EnvironmentsList extends React.Component {
     });
   }
 
-  get envsStore() {
-    return this.props.scEnvironmentsStore;
-  }
-
   get viewStore() {
     return this.props.ScEnvView || VIEW.NORMAL;
   }
@@ -53,4 +49,4 @@ decorate(EnvironmentsList, {
   compact: observable,
 });
 
-export default inject('ScEnvView', 'scEnvironmentsStore')(observer(EnvironmentsList));
+export default inject('ScEnvView')(observer(EnvironmentsList));

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/plugins/app-context-items-plugin.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/plugins/app-context-items-plugin.js
@@ -33,6 +33,7 @@ import * as scEnvironmentsStore from '../models/environments-sc/ScEnvironmentsSt
 import * as scEnvironmentCostsStore from '../models/environments-sc/ScEnvironmentCostsStore';
 import * as dataSourceAccountsStore from '../models/data-sources/DataSourceAccountsStore';
 import * as registerStudyWizard from '../models/data-sources/register/RegisterStudyWizard';
+import * as ScEnvViewStore from '../models/environments-sc/advanced/ScEnvView';
 import { enableBuiltInWorkspaces } from '../helpers/settings';
 
 // eslint-disable-next-line no-unused-vars
@@ -57,6 +58,7 @@ function registerAppContextItems(appContext) {
   scEnvironmentCostsStore.registerContextItems(appContext);
   dataSourceAccountsStore.registerContextItems(appContext);
   registerStudyWizard.registerContextItems(appContext);
+  ScEnvViewStore.registerContextItems(appContext);
 
   // console.log('enableBuiltInWorkspaces', enableBuiltInWorkspaces);
   // If built in workspaces are enabled then do not show environment type management


### PR DESCRIPTION
- Add search field to normal workspace view.
- Add an advanced workspace table view with sorting & filtering.
- Set workspace CFT info as default tab on workspace detail page.
- Hide termination toggle on detail view for workspaces that can't be terminated.

**Notes**: All the new components I added i used the functional component style instead of the class style. I found this made more sense to me and was a bit cleaner to read. However, when I needed the mobx statetree, I used the class component style and imported mobx state like all the other SWB code does it.

**Live in Aim-Ahead non-fisma DEV**

Checklist:
- [x] Have you successfully deployed to an AWS account with your changes?
- [x] Have you successfully tested with your changes locally?

Ticket: None.

----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.