### PR TITLE
Update serverless templates to have default empty value for profile.

### DIFF
--- a/main/config/settings/.defaults.yml
+++ b/main/config/settings/.defaults.yml
@@ -232,3 +232,5 @@ dbEnvironmentsSc: ${self:custom.settings.dbPrefix}-EnvironmentsSc
 
 # Use Custom AMIs that are already managed by other process like golden image pipeline
 useCustomAmi: false
+
+useAwsProfile: false

--- a/main/solution/backend/config/settings/.defaults.yml
+++ b/main/solution/backend/config/settings/.defaults.yml
@@ -315,5 +315,3 @@ dataSourceReachabilityHandlerRoleArn: 'arn:aws:iam::${self:custom.settings.awsAc
 backendStackName: ${self:custom.settings.namespace}-backend
 
 envMgmtRoleArn: ${self:custom.settings.backendStackName}.EnvMgmtRoleArn}
-
-useAwsProfile: true

--- a/main/solution/backend/serverless.yml
+++ b/main/solution/backend/serverless.yml
@@ -50,7 +50,7 @@ custom:
     environmentOverrides: # when running locally
       provider:
         APP_AWS_REGION: ${self:custom.settings.awsRegion} # this is needed for local development
-        APP_AWS_PROFILE: ${self:custom.settings.awsProfile} # this is needed for local development
+        APP_AWS_PROFILE: ${self:custom.settings.awsProfile, ""} # this is needed for local development
         APP_USE_AWS_PROFILE: ${self:custom.settings.useAwsProfile, ""}
         IS_OFFLINE: true
         APP_LOCAL_ROLE_AUTO_ADJUST_TRUST: ${self:custom.settings.localRoleAutoAdjustTrust} # Auto adjust trust policy of the lambda execution role to allow assumeRole from local machine

--- a/main/solution/post-deployment/config/settings/.defaults.yml
+++ b/main/solution/post-deployment/config/settings/.defaults.yml
@@ -317,8 +317,6 @@ postDeploymentHandlerRoleName: ${self:custom.settings.namespace}-postDeployment-
 # The IAM role arn for the Lambda Post Deployment handler, we need to define it in the settings because it is being passed to lambdas as an env var
 postDeploymentHandlerRoleArn: 'arn:aws:iam::${self:custom.settings.awsAccountInfo.awsAccountId}:role/${self:custom.settings.postDeploymentHandlerRoleName}'
 
-useAwsProfile: true
-
 #===============================WAF=IP=Rate=Limit===========================================================
 # Per ip, per 5 minutes
 wafIpRateLimit: 1000

--- a/main/solution/post-deployment/serverless.yml
+++ b/main/solution/post-deployment/serverless.yml
@@ -40,7 +40,7 @@ custom:
     environmentOverrides: # when running locally
       provider:
         APP_AWS_REGION: ${self:custom.settings.awsRegion} # this is needed for local development
-        APP_AWS_PROFILE: ${self:custom.settings.awsProfile} # this is needed for local development
+        APP_AWS_PROFILE: ${self:custom.settings.awsProfile, ""} # this is needed for local development
         APP_USE_AWS_PROFILE: ${self:custom.settings.useAwsProfile, ""}
         IS_OFFLINE: true
         APP_LOCAL_ROLE_AUTO_ADJUST_TRUST: ${self:custom.settings.localRoleAutoAdjustTrust} # Auto adjust trust policy of the lambda execution role to allow assumeRole from local machine

--- a/main/solution/pre-deployment/config/settings/.defaults.yml
+++ b/main/solution/pre-deployment/config/settings/.defaults.yml
@@ -22,5 +22,3 @@ preDeploymentHandlerRoleName: ${self:custom.settings.namespace}-preDeployment-Ro
 
 # The IAM role arn for the Lambda Pre Deployment handler, we need to define it in the settings because it is being passed to lambdas as an env var
 preDeploymentHandlerRoleArn: 'arn:aws:iam::${self:custom.settings.awsAccountInfo.awsAccountId}:role/${self:custom.settings.preDeploymentHandlerRoleName}'
-
-useAwsProfile: true

--- a/main/solution/pre-deployment/serverless.yml
+++ b/main/solution/pre-deployment/serverless.yml
@@ -40,7 +40,7 @@ custom:
     environmentOverrides: # when running locally
       provider:
         APP_AWS_REGION: ${self:custom.settings.awsRegion} # this is needed for local development
-        APP_AWS_PROFILE: ${self:custom.settings.awsProfile} # this is needed for local development
+        APP_AWS_PROFILE: ${self:custom.settings.awsProfile, ""} # this is needed for local development
         APP_USE_AWS_PROFILE: ${self:custom.settings.useAwsProfile, ""}
         IS_OFFLINE: true
         APP_LOCAL_ROLE_AUTO_ADJUST_TRUST: ${self:custom.settings.localRoleAutoAdjustTrust} # Auto adjust trust policy of the lambda execution role to allow assumeRole from local machine


### PR DESCRIPTION
Update serverless templates to use an empty string for aws profile, like AWS SWB does. This should fix the ci/cd deploy issue where it can't find the value and kills itself.

Checklist:
- [X] Have you successfully deployed to an AWS account with your changes?

Ticket: ALS-4854

----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.