### PR TITLE
Restrict the WAF rate limiting to the api/register route

### DIFF
--- a/main/solution/post-deployment/config/infra/registrationWAF.yml
+++ b/main/solution/post-deployment/config/infra/registrationWAF.yml
@@ -23,7 +23,7 @@ Resources:
               ScopeDownStatement: # Scope rate limiting to 'api' requests
                 # Documentation: https://docs.aws.amazon.com/waf/latest/developerguide/waf-bot-control-example-scope-down-login.html
                 ByteMatchStatement:
-                  SearchString: "/api"
+                  SearchString: "/api/register"
                   FieldToMatch:
                     UriPath: {}
                   TextTransformations:

--- a/main/solution/post-deployment/config/settings/.defaults.yml
+++ b/main/solution/post-deployment/config/settings/.defaults.yml
@@ -323,5 +323,5 @@ postDeploymentHandlerRoleArn: 'arn:aws:iam::${self:custom.settings.awsAccountInf
 
 #===============================WAF=IP=Rate=Limit===========================================================
 # Per ip, per 5 minutes
-wafIpRateLimit: 1000
+wafIpRateLimit: 200
 


### PR DESCRIPTION
When the dashboard page is loaded, and there are many envs, the throttle hits could be pretty aggressive. (The dashboard individually sends a request to the server for each env, so if there's 600 envs, it will send 600 requests. While this is not ideal, and should be fixed in the future, at the moment the throttle will kill a user at 2 page reloads in this scenario.)

The original intent of the throttle was to restrict the open (unauthenticated) register endpoint so a user can maliciously spam a ton of registration requests. Setting the limit for that lower, and restricting to this endpoint to api/register, should solve the issue without removing the security we intended.

Checklist:
- [X] Have you successfully deployed to an AWS account with your changes?
- [X] Have you successfully tested with your changes locally?

----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.