### PR TITLE
[ALS-5307] Omit user store fields for api update/create user request

### DIFF
--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/helpers/api.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/helpers/api.js
@@ -83,13 +83,16 @@ function updateUserApplication(user) {
   const data = removeNulls(
     _.omit(
       _.clone(user),
-      'uid',
-      'authenticationProviderId',
-      'identityProviderName',
-      'username',
-      'ns',
-      'createdBy',
-      'updatedBy',
+      [
+        'uid',
+        'authenticationProviderId',
+        'identityProviderName',
+        'username',
+        'ns',
+        'createdAt',
+        'createdBy',
+        'updatedBy',
+      ]
     ),
   );
   if (!data.userType) {

--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/users/UsersList.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/users/UsersList.js
@@ -160,9 +160,14 @@ class UsersList extends React.Component {
           }}
           columns={[
             {
+              Header: 'Name',
+              accessor: 'displayName',
+              width: 150,
+            },
+            {
               Header: 'Email',
               accessor: 'email',
-              width: 275,
+              width: 215,
             },
             {
               Header: 'Identity Provider',
@@ -175,7 +180,7 @@ class UsersList extends React.Component {
             {
               Header: 'Type',
               accessor: 'isExternalUser',
-              width: 100,
+              width: 80,
               Cell: row => {
                 const user = row.original;
                 return user.isExternalUser ? 'External' : 'Internal';

--- a/addons/addon-base-ui/packages/base-ui/src/helpers/api.js
+++ b/addons/addon-base-ui/packages/base-ui/src/helpers/api.js
@@ -248,11 +248,18 @@ function addUser(user) {
   if (user.identityProviderName) {
     params.identityProviderName = user.identityProviderName;
   }
-  const data = removeNulls(_.clone(user));
-  delete data.ns; // Server derives ns based on "authenticationProviderId" and "identityProviderName"
-  // on server side so remove it from request body
-  delete data.createdBy; // Similarly, createdBy and updatedBy are derived on server side
-  delete data.updatedBy;
+  const data = removeNulls(
+    _.omit(
+      _.clone(user),
+      [
+        'createdBy',
+        'createdAt',
+        'updatedBy',
+        'ns',
+        'userType',
+      ]
+    )
+  );
   if (!data.userType) {
     // if userType is specified as empty string then make sure to delete it
     // the api requires this to be only one of the supported values (currently only supported value is 'root')
@@ -274,6 +281,7 @@ function updateUser(user) {
       'identityProviderName',
       'username',
       'ns',
+      'createdAt',
       'createdBy',
       'updatedBy',
     ),


### PR DESCRIPTION
Since the user store now has the createdAt field, it is sent in api requests, which block fields not listed in the validation scheme. We also don't need to send this in the request, so we're going to omit from user create/update requests.

Also, simran requested adding a user name column. So just adding that in and changing default widths.

Checklist:
- [X] Have you successfully tested with your changes locally?
- [x] Have you successfully deployed to an AWS account with your changes?

----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.