### PR TITLE
[ALS-5505] Update to add 'and' to scanner filter when more than one filter condition exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file. As our fork has diverged from AWS SWB mainline branch, we are noting the SWB version and the lab version together, as <swb version>\_<lab version>, starting from SWB mainline, 5.0.0.
 
+## [5.0.0_1.3.1](https://github.com/hms-dbmi/service-workbench-on-aws/compare/v5.0.0_1.3.0...v5.0.0_1.3.1) (12/13/2023)
+- Bugfix: Update to add 'and' to scanner filter when more than one filter condition exists.
+
 ## [5.0.0_1.3.0](https://github.com/hms-dbmi/service-workbench-on-aws/compare/v5.0.0_1.2.0...v5.0.0_1.3.0) (12/08/2023)
 ### Workspaces
 - Update windows sync to auto-start on user login.

--- a/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/environment-sc-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/environment-sc-service.js
@@ -123,22 +123,23 @@ class EnvironmentScService extends Service {
       scanner = scanner.start({ id: offsetId });
     }
 
+    const scannerFilters = [];
     if (!isAdmin(requestContext)) {
       const currentUser = _.get(requestContext, 'principalIdentifier.uid');
       if (!currentUser) {
         throw this.boom.badRequest(`Principal Identifier not found`, true);
       }
-      scanner = await scanner
-        .names({ '#c': 'createdBy' })
-        .values({ ':c': currentUser })
-        .filter('#c = :c');
+      scanner = await scanner.names({ '#c': 'createdBy' }).values({ ':c': currentUser });
+      scannerFilters.push('#c = :c');
     }
 
     if (since && isoTimestamp.test(since)) {
-      scanner = scanner
-        .names({ '#u': 'updatedAt' })
-        .values({ ':u': since })
-        .filter('#u >= :u');
+      scanner = scanner.names({ '#u': 'updatedAt' }).values({ ':u': since });
+      scannerFilters.push('#u >= :u');
+    }
+
+    if (scannerFilters.length > 0) {
+      scanner = scanner.filter(scannerFilters.join(' and '));
     }
 
     // Only accept fields from a list of allowed db fields


### PR DESCRIPTION
When a user logs into SWB as a researcher the API returns a validation error.

In my local, this returns an error message (although id doesn't seem to display a message in prod). Regardless, because of this the env data does not successfully refresh without a manual page reload.

The cause of the validation error is the applied since and createdBy filters. When multiple filters were applied, it was sending the filter expression as `#c = :c #u = :u` instead of `#c = :c and #u = :u`, which is required for scanner operations.

Checklist:
- [X] Have you successfully tested with your changes locally?
- [x] Have you successfully deployed to an AWS account with your changes?

----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.