### PR TITLE
[ALS-5632] Add comma separated study whitelist in stage file

### DIFF
--- a/main/solution/backend/config/infra/functions.yml
+++ b/main/solution/backend/config/infra/functions.yml
@@ -20,6 +20,7 @@ openDataScrapeHandler:
     APP_STUDY_DATA_BUCKET_NAME: ${self:custom.settings.studyDataBucketName}
     APP_CUSTOM_USER_AGENT: ${self:custom.settings.customUserAgent}
     APP_IS_APP_STREAM_ENABLED: ${self:custom.settings.isAppStreamEnabled}
+    APP_OPEN_DATA_SCRAPE_WHITELIST: ${self:custom.settings.openDataScrapeWhitelist}
 
   events:
     - schedule:

--- a/main/solution/backend/config/settings/.defaults.yml
+++ b/main/solution/backend/config/settings/.defaults.yml
@@ -321,3 +321,6 @@ dataSourceReachabilityHandlerRoleArn: 'arn:aws:iam::${self:custom.settings.awsAc
 
 # The stack name of the 'backend' serverless service
 backendStackName: ${self:custom.settings.namespace}-backend
+
+# custom list of open studies to include when scraping that are not part in the filtered tag list
+openDataScrapeWhitelist: ''

--- a/main/solution/backend/src/lambdas/open-data-scrape-handler/__tests__/handler-impl.test.js
+++ b/main/solution/backend/src/lambdas/open-data-scrape-handler/__tests__/handler-impl.test.js
@@ -113,33 +113,83 @@ describe('fetchOpenData', () => {
     sha: 'abc2',
   };
 
+  const whitelistStudy = {
+    name: 'Study 3',
+    description: 'Example study 3',
+    tags: ['other-tag'],
+    resources: [
+      {
+        description: 'Description for Study 3',
+        arn: 'arn:aws:s3:::study3',
+        region: 'us-east-1',
+        type: 'S3 Bucket',
+      },
+    ],
+    id: 'study-3',
+    sha: 'abc2',
+  };
+
   it('has invalid study (Invalid ARN)', async () => {
     const fileUrls = ['firstFileUrl'];
     const requiredTags = ['genetic'];
+    const studyWhitelist = [];
     const fetchFile = jest.fn();
     fetchFile.mockReturnValueOnce(invalidStudy);
 
-    const result = await fetchOpenData({ fileUrls, requiredTags, log: consoleLogger, fetchFile });
+    const result = await fetchOpenData({ fileUrls, requiredTags, studyWhitelist, log: consoleLogger, fetchFile });
     expect(result).toEqual([]);
   });
 
   it('has one valid study', async () => {
     const fileUrls = ['firstFileUrl'];
     const requiredTags = ['genetic'];
+    const studyWhitelist = [];
     const fetchFile = jest.fn();
     fetchFile.mockReturnValueOnce(validStudy);
 
-    const result = await fetchOpenData({ fileUrls, requiredTags, log: consoleLogger, fetchFile });
+    const result = await fetchOpenData({ fileUrls, requiredTags, studyWhitelist, log: consoleLogger, fetchFile });
     expect(result).toEqual([validStudyOpenData]);
   });
 
   it('has one valid study and one invalid study (Invalid ARN)', async () => {
-    const fileUrls = ['firstFileUrl'];
+    const fileUrls = ['firstFileUrl', 'fileUrl2'];
     const requiredTags = ['genetic'];
+    const studyWhitelist = [];
     const fetchFile = jest.fn();
     fetchFile.mockReturnValueOnce(validStudy).mockReturnValueOnce(invalidStudy);
 
-    const result = await fetchOpenData({ fileUrls, requiredTags, log: consoleLogger, fetchFile });
+    const result = await fetchOpenData({ fileUrls, requiredTags, studyWhitelist, log: consoleLogger, fetchFile });
     expect(result).toEqual([validStudyOpenData]);
+  });
+
+  it('has whitelisted study is included', async () => {
+    const fileUrls = ['firstFileUrl', 'fileUrl2', 'fileUrl3'];
+    const requiredTags = ['genetic'];
+    const studyWhitelist = ['study-3'];
+    const fetchFile = jest.fn();
+    fetchFile
+      .mockReturnValueOnce(validStudy)
+      .mockReturnValueOnce(invalidStudy)
+      .mockReturnValueOnce(whitelistStudy);
+
+    const result = await fetchOpenData({ fileUrls, requiredTags, studyWhitelist, log: consoleLogger, fetchFile });
+    expect(result).toEqual([
+      validStudyOpenData,
+      {
+        description: 'Example study 3',
+        id: 'study-3',
+        name: 'Study 3',
+        resources: [
+          {
+            arn: 'arn:aws:s3:::study3',
+            description: 'Description for Study 3',
+            region: 'us-east-1',
+            type: 'S3 Bucket',
+          },
+        ],
+        sha: 'abc2',
+        tags: ['other-tag'],
+      },
+    ]);
   });
 });

--- a/main/solution/backend/src/lambdas/open-data-scrape-handler/handler-impl.js
+++ b/main/solution/backend/src/lambdas/open-data-scrape-handler/handler-impl.js
@@ -203,10 +203,8 @@ const fetchOpenData = async ({ fileUrls, requiredTags, studyWhitelist, log, fetc
   const validS3Arn = new RegExp(/^arn:aws:s3:.*:.*:.+$/);
   const filtered = metadata.filter(({ id, tags, resources }) => {
     return (
-      (
-        studyWhitelist.includes(id) ||
-        requiredTags.some(filterTag => tags.includes(filterTag))
-      ) && resources.every(resource => {
+      (studyWhitelist.includes(id) || requiredTags.some(filterTag => tags.includes(filterTag))) &&
+      resources.every(resource => {
         return resource.type === 'S3 Bucket' && validS3Arn.test(resource.arn);
       })
     );
@@ -246,7 +244,7 @@ const fetchAndSaveOpenData = async (fetchDatasetFiles, scrape, log, fetchFile, b
     requiredTags: scrape.filterTags,
     studyWhitelist: scrape.studyWhitelist,
     log,
-    fetchFile
+    fetchFile,
   });
 
   const simplifiedStudyData = openData.map(basicProjection);

--- a/main/solution/backend/src/lambdas/open-data-scrape-handler/handler-impl.js
+++ b/main/solution/backend/src/lambdas/open-data-scrape-handler/handler-impl.js
@@ -42,7 +42,8 @@ if (typeof fetch !== 'function' && fetch.default && typeof fetch.default === 'fu
   fetch = fetch.default;
 }
 
-const newHandler = async ({ studyService, log = consoleLogger } = {}) => {
+const newHandler = async ({ studyService, log = consoleLogger, settings } = {}) => {
+  const whitelist = settings.get('openDataScrapeWhitelist') || '';
   const scrape = {
     githubApiUrl: 'https://api.github.com',
     rawGithubUrl: 'https://raw.githubusercontent.com',
@@ -50,6 +51,7 @@ const newHandler = async ({ studyService, log = consoleLogger } = {}) => {
     repository: 'open-data-registry',
     ref: 'main',
     subtree: 'datasets',
+    studyWhitelist: whitelist.split(',').filter(x => x),
     filterTags: [
       'genetic',
       'genomic',
@@ -193,16 +195,18 @@ const newHandler = async ({ studyService, log = consoleLogger } = {}) => {
   return async () => fetchAndSaveOpenData(fetchDatasetFiles, scrape, log, fetchFile, basicProjection, studyService);
 };
 
-const fetchOpenData = async ({ fileUrls, requiredTags, log, fetchFile }) => {
+const fetchOpenData = async ({ fileUrls, requiredTags, studyWhitelist, log, fetchFile }) => {
   log.info(`Fetching ${fileUrls.length} metadata files`);
   const metadata = await Promise.all(fileUrls.map(fetchFile));
 
-  log.info(`Filtering for ${requiredTags} tags and resources with valid ARNs`);
+  log.info(`Filtering for ${requiredTags} tags, ${studyWhitelist} whitelist studies, and resources with valid ARNs`);
   const validS3Arn = new RegExp(/^arn:aws:s3:.*:.*:.+$/);
-  const filtered = metadata.filter(({ tags, resources }) => {
+  const filtered = metadata.filter(({ id, tags, resources }) => {
     return (
-      requiredTags.some(filterTag => tags.includes(filterTag)) &&
-      resources.every(resource => {
+      (
+        studyWhitelist.includes(id) ||
+        requiredTags.some(filterTag => tags.includes(filterTag))
+      ) && resources.every(resource => {
         return resource.type === 'S3 Bucket' && validS3Arn.test(resource.arn);
       })
     );
@@ -237,7 +241,13 @@ async function saveOpenData(log, simplified, studyService) {
 
 const fetchAndSaveOpenData = async (fetchDatasetFiles, scrape, log, fetchFile, basicProjection, studyService) => {
   const fileUrls = await fetchDatasetFiles();
-  const openData = await fetchOpenData({ fileUrls, requiredTags: scrape.filterTags, log, fetchFile });
+  const openData = await fetchOpenData({
+    fileUrls,
+    requiredTags: scrape.filterTags,
+    studyWhitelist: scrape.studyWhitelist,
+    log,
+    fetchFile
+  });
 
   const simplifiedStudyData = openData.map(basicProjection);
 

--- a/main/solution/backend/src/lambdas/open-data-scrape-handler/handler.js
+++ b/main/solution/backend/src/lambdas/open-data-scrape-handler/handler.js
@@ -26,7 +26,8 @@ const initHandler = (async () => {
   await container.initServices();
   const studyService = await container.find('studyService');
   const log = await container.find('log');
-  return newHandler({ studyService, log });
+  const settings = await container.find('settings');
+  return newHandler({ studyService, log, settings });
 })();
 
 // eslint-disable-next-line import/prefer-default-export


### PR DESCRIPTION
- Add a parameter in the stage deployment config file to add studies that can be added to the open-data studies tab in SWB ui, even if the study is not part of the default filtered open-data study tags.

Checklist:
- [x] Have you successfully tested with your changes locally?
- [ ] Have you successfully deployed to an AWS account with your changes?

----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.