### PR TITLE
[ALS-5542] Add PIC-SURE landing page if stage parameter is set

### DIFF
--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/users/UserStore.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/users/UserStore.js
@@ -18,12 +18,14 @@ import { types } from 'mobx-state-tree';
 
 import { getUser } from '@aws-ee/base-ui/dist/helpers/api';
 import { BaseStore } from '@aws-ee/base-ui/dist/models/BaseStore';
+import { branding } from '@aws-ee/base-ui/dist/helpers/settings';
 
 import { User } from './User';
 
 const UserStore = BaseStore.named('UserStore')
   .props({
     user: types.maybe(User),
+    picsureLanding: branding.main.picsureLanding,
   })
   .actions(self => {
     // save the base implementation of cleanup
@@ -36,6 +38,11 @@ const UserStore = BaseStore.named('UserStore')
           self.user = User.create(user);
         });
       },
+      bypassLanding() {
+        self.runInAction(() => {
+          self.picsureLanding = false;
+        });
+      },
       cleanup: () => {
         self.user = undefined;
         superCleanup();
@@ -46,6 +53,10 @@ const UserStore = BaseStore.named('UserStore')
   .views(self => ({
     get empty() {
       return _.isEmpty(self.user);
+    },
+
+    get defaultLocation() {
+      return self.picsureLanding ? '/landing' : '/dashboard';
     },
 
     // TODO this method should really be moved to the User model and renamed to something like projectIdOptions

--- a/addons/addon-base-ui/packages/base-ui/src/helpers/settings.js
+++ b/addons/addon-base-ui/packages/base-ui/src/helpers/settings.js
@@ -38,6 +38,8 @@ const branding = {
   main: {
     title: process.env.REACT_APP_BRAND_MAIN_TITLE,
     loginWarning: process.env.REACT_APP_LOGIN_WARNING,
+    picsureLanding: process.env.REACT_APP_PICSURE_LANDING === 'true',
+    picsureUrl: process.env.REACT_APP_PICSURE_URL || '',
   },
   page: {
     title: process.env.REACT_APP_BRAND_PAGE_TITLE,

--- a/addons/addon-base-ui/packages/base-ui/src/parts/MainLayout.js
+++ b/addons/addon-base-ui/packages/base-ui/src/parts/MainLayout.js
@@ -79,7 +79,7 @@ class MainLayout extends React.Component {
         })}
       </Menu>,
 
-      <Menu inverted color="black" fixed="top" className="box-shadow zindex-1500" key="ml2">
+      <Menu inverted color="black" fixed="top" className="box-shadow" key="ml2">
         <Menu.Item style={{ height: '50px', verticalAlign: 'middle' }}>
           <Image
             size="mini"

--- a/addons/addon-custom/packages/main/css/overrides.css
+++ b/addons/addon-custom/packages/main/css/overrides.css
@@ -25,3 +25,16 @@ button.link {
   padding: 0px;
   cursor: pointer;
 }
+
+.ui.dimmer {
+  padding: 0px;
+  margin: 0px;
+}
+
+.ui.fullscreen.modal {
+  width: 100% !important;
+  height: 100%;
+  padding: 0px;
+  margin: 0px !important;
+  border-radius: 0px;
+}

--- a/addons/addon-custom/packages/main/src/parts/PicSureLanding.js
+++ b/addons/addon-custom/packages/main/src/parts/PicSureLanding.js
@@ -1,0 +1,70 @@
+import React from 'react';
+import { inject, observer } from 'mobx-react';
+import { decorate, computed } from 'mobx';
+import { Button, Grid, Image, Modal } from 'semantic-ui-react';
+
+import { gotoFn } from '@aws-ee/base-ui/dist/helpers/routing';
+import { branding } from '@aws-ee/base-ui/dist/helpers/settings';
+
+class PicSureLanding extends React.Component {
+  get userStore() {
+    return this.props.userStore;
+  }
+
+  gotoLogin() {
+    return () => {
+      this.userStore.bypassLanding();
+      gotoFn(this)('/');
+    };
+  }
+
+  render() {
+    const borders = {
+      margin: '0px 10px',
+      border: 'solid #2A5FA3 2px',
+      borderRadius: '4px',
+      padding: '10px',
+      backgroundColor: 'white',
+    };
+    const maxImageWidth = { height: 'auto', maxWidth: '600px', margin: 'auto' };
+
+    return (
+      <Modal id="picsure-landing" size="fullscreen" closeOnEscape open>
+        <Modal.Content>
+          <Grid id="picsure-splash" verticalAlign="middle" style={{ maxWidth: '800px', margin: '0 auto' }}>
+            <Grid.Row columns={1}>
+              <Grid.Column>
+                <Image fluid src={this.props.assets.images.registerLogo} style={maxImageWidth} />
+              </Grid.Column>
+            </Grid.Row>
+            <Grid.Row columns={2}>
+              <Grid.Column>
+                <Button className="center" style={borders} onClick={this.gotoLogin()}>
+                  <h3 className="header" style={{ textTransform: 'uppercase' }}>
+                    VISIT SERVICE WORKBENCH
+                  </h3>
+                  <p>Simple, accessible cloud computing & secure data storage.</p>
+                </Button>
+              </Grid.Column>
+              <Grid.Column>
+                {/* <Button className="center" style={borders} onClick={this.gotoPicSure()}> */}
+                <Button as="a" href={branding.main.picsureUrl} className="center" style={borders}>
+                  <h3 className="header" style={{ textTransform: 'uppercase' }}>
+                    VISIT PIC-SURE
+                  </h3>
+                  <p>A self-service, easily navigable patient-level clinical data search and cohort tool.</p>
+                </Button>
+              </Grid.Column>
+            </Grid.Row>
+          </Grid>
+        </Modal.Content>
+      </Modal>
+    );
+  }
+}
+
+// see https://medium.com/@mweststrate/mobx-4-better-simpler-faster-smaller-c1fbc08008da
+decorate(PicSureLanding, {
+  userStore: computed,
+});
+export default inject('assets', 'userStore')(observer(PicSureLanding));

--- a/addons/addon-custom/packages/main/src/parts/PicSureLanding.js
+++ b/addons/addon-custom/packages/main/src/parts/PicSureLanding.js
@@ -58,7 +58,6 @@ class PicSureLanding extends React.Component {
                 </Button>
               </Grid.Column>
               <Grid.Column>
-                {/* <Button className="center" style={borders} onClick={this.gotoPicSure()}> */}
                 <Button as="a" href={branding.main.picsureUrl} className="center" style={borders}>
                   <h3 className="header" style={h3}>
                     VISIT PIC-SURE

--- a/addons/addon-custom/packages/main/src/parts/PicSureLanding.js
+++ b/addons/addon-custom/packages/main/src/parts/PicSureLanding.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { inject, observer } from 'mobx-react';
 import { decorate, computed } from 'mobx';
-import { Button, Grid, Image, Modal } from 'semantic-ui-react';
+import { Button, Grid, Image, Modal, Header } from 'semantic-ui-react';
 
 import { gotoFn } from '@aws-ee/base-ui/dist/helpers/routing';
 import { branding } from '@aws-ee/base-ui/dist/helpers/settings';
@@ -26,6 +26,7 @@ class PicSureLanding extends React.Component {
       padding: '10px',
       backgroundColor: 'white',
     };
+    const h3 = { textTransform: 'uppercase', color: '#2A5FA3', textDecoration: 'underline' };
     const maxImageWidth = { height: 'auto', maxWidth: '600px', margin: 'auto' };
 
     return (
@@ -37,10 +38,20 @@ class PicSureLanding extends React.Component {
                 <Image fluid src={this.props.assets.images.registerLogo} style={maxImageWidth} />
               </Grid.Column>
             </Grid.Row>
+            <Grid.Row columns={1}>
+              <Grid.Column className="bodyText">
+                <div className="center">
+                  <Header as="h2" textAlign="center" className="header">
+                    {branding.register.title}
+                  </Header>
+                  <p>You are logged in to the Data Exploration + Analysis tool suite.</p>
+                </div>
+              </Grid.Column>
+            </Grid.Row>
             <Grid.Row columns={2}>
               <Grid.Column>
                 <Button className="center" style={borders} onClick={this.gotoLogin()}>
-                  <h3 className="header" style={{ textTransform: 'uppercase' }}>
+                  <h3 className="header" style={h3}>
                     VISIT SERVICE WORKBENCH
                   </h3>
                   <p>Simple, accessible cloud computing & secure data storage.</p>
@@ -49,7 +60,7 @@ class PicSureLanding extends React.Component {
               <Grid.Column>
                 {/* <Button className="center" style={borders} onClick={this.gotoPicSure()}> */}
                 <Button as="a" href={branding.main.picsureUrl} className="center" style={borders}>
-                  <h3 className="header" style={{ textTransform: 'uppercase' }}>
+                  <h3 className="header" style={h3}>
                     VISIT PIC-SURE
                   </h3>
                   <p>A self-service, easily navigable patient-level clinical data search and cohort tool.</p>

--- a/addons/addon-custom/packages/main/src/plugins/routes-plugin.js
+++ b/addons/addon-custom/packages/main/src/plugins/routes-plugin.js
@@ -12,11 +12,13 @@
  *  express or implied. See the License for the specific language governing
  *  permissions and limitations under the License.
  */
+import _ from 'lodash';
 
 import withAuth from '@aws-ee/base-ui/dist/withAuth';
 
 import TermsPage from '../parts/TermsPage';
 import Register from '../parts/Register';
+import PicSureLanding from '../parts/PicSureLanding';
 
 /**
  * Adds your routes to the given routesMap.
@@ -29,10 +31,35 @@ import Register from '../parts/Register';
  */
 // eslint-disable-next-line no-unused-vars
 function registerRoutes(routesMap, { location, appContext }) {
-  const routes = new Map([...routesMap, ['/register', withAuth(Register)], ['/legal', withAuth(TermsPage)]]);
+  const routes = new Map([
+    ...routesMap,
+    ['/landing', withAuth(PicSureLanding)],
+    ['/register', withAuth(Register)],
+    ['/legal', withAuth(TermsPage)],
+  ]);
   return routes;
 }
 
-const plugin = { registerRoutes };
+/**
+ * Returns default route. By default this method returns the
+ * '/dashboard' route as the default route for all non-root users and returns
+ * '/users' route for root user.
+ * @returns {{search: *, state: *, hash: *, pathname: string}}
+ */
+function getDefaultRouteLocation({ location, appContext }) {
+  const userStore = appContext.userStore;
+  const userDefaultLocation = _.get(userStore, 'defaultLocation');
+
+  const defaultLocation = {
+    pathname: userDefaultLocation,
+    search: location.search, // we want to keep any query parameters
+    hash: location.hash,
+    state: location.state,
+  };
+
+  return defaultLocation;
+}
+
+const plugin = { registerRoutes, getDefaultRouteLocation };
 
 export default plugin;

--- a/main/config/settings/example.yml
+++ b/main/config/settings/example.yml
@@ -165,3 +165,7 @@ HostedZoneId: 'Z02455261RJ9QQPVHFZGA'
 
 # URL for help link. Can be empty, a single url, or a list like, "Some Link=https://www.google.com/?q=what,Other Link=https://www.example.com/"
 #helpUrl: about:blank
+
+# Redirect to the pic-sure integrated landing page to allow users to select picsure or swb logins
+# piscureLanding: false
+# piscureUrl: ''

--- a/main/solution/ui/config/environment/env-template.yml
+++ b/main/solution/ui/config/environment/env-template.yml
@@ -28,6 +28,8 @@ REACT_APP_LOGIN_WARNING: ${self:custom.settings.loginWarning}
 REACT_APP_HELP_URL: ${self:custom.settings.helpUrl}
 REACT_APP_USER_REGISTRATION_TOS_REQUIRED: ${self:custom.settings.tosRequired}
 REACT_APP_TOS_LINK_ON_LANDING: ${self:custom.settings.tosLinkOnLanding}
+REACT_APP_PICSURE_LANDING: ${self:custom.settings.piscureLanding}
+REACT_APP_PICSURE_URL: ${self:custom.settings.piscureUrl}
 
 # ========================================================================
 # Overrides for .env.local

--- a/main/solution/ui/config/settings/.defaults.yml
+++ b/main/solution/ui/config/settings/.defaults.yml
@@ -38,5 +38,9 @@ loginWarning: ""
 # Require the TOS to be accepted before registration can occur.
 tosRequired: true
 
-# Should the TOS link be enabled on the landing page.
+# Should the TOS link be enabled on the login page.
 tosLinkOnLanding: true
+
+# Redirect to the pic-sure integrated landing page to allow users to select picsure or swb logins
+piscureLanding: false
+piscureUrl: ''


### PR DESCRIPTION
After successful login, add a landing modal/page that displays the picsure and swb links. If the user selects the picsure link, redirect to that page. If the user selects the swb link, redirect to default swb page.

Checklist:
- [X] Have you successfully tested with your changes locally?
- [ ] Have you successfully deployed to an AWS account with your changes?

----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.