### PR TITLE
[ALS-5982] Move conda env config to install_kernel script

### DIFF
--- a/main/solution/post-deployment/config/environment-files/environments/sagemaker.sh
+++ b/main/solution/post-deployment/config/environment-files/environments/sagemaker.sh
@@ -1,17 +1,5 @@
 #!/usr/bin/env bash
 
-# --------------------------- Load Kernels to Conda -------------------------- #
-KERNEL_PATH="/home/ec2-user/SageMaker/.kernels"
-echo "Adding $KERNEL_PATH to conda configuration"
-mkdir -p $KERNEL_PATH
-chown ec2-user:ec2-user $KERNEL_PATH
-cat << EOF >> /home/ec2-user/.condarc
-envs_dirs:
-  - $KERNEL_PATH
-  - /home/ec2-user/anaconda3/envs
-EOF
-echo "Finished Adding $KERNEL_PATH to conda configuration"
-
 # --------------------------------- Idle Stop -------------------------------- #
 if [ "$AUTO_STOP_IDLE_TIME" != "0" ]; then
   echo "Installing the idle stop script"

--- a/main/solution/post-deployment/config/environment-files/get_bootstrap.sh
+++ b/main/solution/post-deployment/config/environment-files/get_bootstrap.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+
+# DEPRECATED - use bootstrap.sh instead
+
 bootstrap_s3_location="$1"
 s3_mounts="$2"
 

--- a/main/solution/post-deployment/config/environment-files/install_kernel.sh
+++ b/main/solution/post-deployment/config/environment-files/install_kernel.sh
@@ -23,3 +23,14 @@ if [ "$kernels" != "" ]; then
     fi
   done
 fi
+
+# --------------------------- Load Kernels to Conda -------------------------- #
+echo "Adding $KERNEL_PATH to conda configuration"
+mkdir -p $KERNEL_PATH
+chown ec2-user:ec2-user $KERNEL_PATH
+cat << EOF >> /home/ec2-user/.condarc
+envs_dirs:
+  - $KERNEL_PATH
+  - /home/ec2-user/anaconda3/envs
+EOF
+echo "Finished Adding $KERNEL_PATH to conda configuration"


### PR DESCRIPTION
- Move conda env config to install kernel script, as FISMA does not use the new environment split bootstrap but the old, deprecated one that was not getting this new config step. Probably need to update FISMA to use the new bootstrap scripts for all workspace types.

Checklist:
- [x] Have you successfully deployed to an AWS account with your changes?

----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.